### PR TITLE
Disable logging for com.itextpdf for anything below "ERROR"

### DIFF
--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -18,6 +18,7 @@ logging:
     ROOT: INFO
     io.github.jhipster: INFO
     eu.cessda.cvs: INFO
+    com.itextpdf: ERROR
 
 management:
   metrics:


### PR DESCRIPTION
This was producing a significant quantity of garbage logs that are only relevant to developers.

See #568 for details