### PR TITLE
Set the root logging level to WARN for the prod profile, fix UserDetails.equals() always throwing ClassCastException

### DIFF
--- a/src/main/java/eu/cessda/cvs/domain/enumeration/Language.java
+++ b/src/main/java/eu/cessda/cvs/domain/enumeration/Language.java
@@ -49,24 +49,32 @@ public enum Language {
     RUSSIAN( "ru", "ru" , "Russian (ru)", "Russian"),
     SERBIAN( "sr", "sr" , "Serbian (sr)", "Serbian"),
     SLOVAK( "sk", "sk" , "Slovak (sk)", "Slovak"),
-    SLOVENIAN( "sl", "sl" , "Slovenian (sl)", "Slovenian"),
-    SPANISH( "es", "es" , "Spanish (es)", "Spanish"),
-    SWEDISH( "sv", "sv" , "Swedish (sv)", "Swedish"),
-    UNKNOWN( "-", "-" , "Unknown (-)", "Unknown");
+    SLOVENIAN("sl", "sl", "Slovenian (sl)", "Slovenian"),
+    SPANISH("es", "es", "Spanish (es)", "Spanish"),
+    SWEDISH("sv", "sv", "Swedish (sv)", "Swedish"),
+    UNKNOWN("-", "-", "Unknown (-)", "Unknown");
 
     private final String iso;
     private final String iso3;
     private final String formatted;
     private final String notes;
 
-    private static Map<String, Language> map;
+    private static final Map<String, Language> LANGUAGE_MAP;
+    private static final Set<String> CAPITALIZED_ISO_SET;
 
     static {
+        // Create a map
         Map<String, Language> langMap = new HashMap<>();
         for (Language lang : Language.values()) {
             langMap.put(lang.iso, lang);
         }
-        map = Collections.unmodifiableMap(langMap);
+        LANGUAGE_MAP = Collections.unmodifiableMap(langMap);
+
+        HashSet<String> set = new HashSet<>();
+        for (String lang : LANGUAGE_MAP.keySet()) {
+            set.add(StringUtils.capitalize(lang));
+        }
+        CAPITALIZED_ISO_SET = Collections.unmodifiableSet(set);
     }
 
     Language(final String iso, final String iso3, final String formatted, final String notes){
@@ -93,7 +101,7 @@ public enum Language {
     }
 
     public static Map<String, Language> getMap() {
-        return map;
+        return LANGUAGE_MAP;
     }
 
     public static List<Language> getFilteredLanguage(Set<Language> userLanguages, Set<String> filterLanguages){
@@ -105,24 +113,23 @@ public enum Language {
             .collect( Collectors.toList());
     }
 
-    public static Set<Language> getLanguagesFromLanguageSet(Set<String> langs){
-        Set<Language> languages = new HashSet<>();
-        for( String lang : langs)
-            languages.add( map.get(lang));
+    public static Set<Language> getLanguagesFromLanguageSet(Set<String> langs) {
+        Set<Language> languages = EnumSet.noneOf(Language.class);
+        for (String lang : langs) {
+            languages.add(LANGUAGE_MAP.get(lang));
+        }
         return languages;
     }
 
     public static Set<String> getCapitalizedIsos(){
-        return map.keySet().stream().map(StringUtils::capitalize).collect(Collectors.toSet());
+        return CAPITALIZED_ISO_SET;
     }
 
     public static Set<String> getIsos(){
-        return new HashSet<>(map.keySet());
+        return new HashSet<>(LANGUAGE_MAP.keySet());
     }
 
     public static Language getByIso(String iso ){
-        if( iso.length() > 2)
-            return null;
-        return map.get(iso.toLowerCase());
+        return LANGUAGE_MAP.get(iso.toLowerCase());
     }
 }

--- a/src/main/java/eu/cessda/cvs/security/ActionType.java
+++ b/src/main/java/eu/cessda/cvs/security/ActionType.java
@@ -17,9 +17,7 @@ package eu.cessda.cvs.security;
 
 import eu.cessda.cvs.domain.enumeration.AgencyRole;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Set;
 
 /**
@@ -27,36 +25,36 @@ import java.util.Set;
  * Each enums contains, types of AgencyRole allowed to perform the action
  */
 public enum ActionType {
-    CREATE_CV( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT))),
-    EDIT_CV( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
-    EDIT_DDI_CV( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
-    EDIT_IDENTITY_CV( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
-    EDIT_VERSION_INFO_CV( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
-    EDIT_NOTE_CV( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
-    DELETE_CV( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
+    CREATE_CV(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT)),
+    EDIT_CV(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
+    EDIT_DDI_CV(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
+    EDIT_IDENTITY_CV(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
+    EDIT_VERSION_INFO_CV(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
+    EDIT_NOTE_CV(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
+    DELETE_CV(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
     // ADD_USAGE_CV( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL))),
-    ADD_TL_CV( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
-    FORWARD_CV_SL_STATUS_REVIEW( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT))),
-    FORWARD_CV_SL_STATUS_READY_TO_TRANSLATE( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT))),
-    FORWARD_CV_SL_STATUS_PUBLISH( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT))),
-    FORWARD_CV_TL_STATUS_REVIEW( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
-    FORWARD_CV_TL_STATUS_READY_TO_PUBLISH( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
+    ADD_TL_CV(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
+    FORWARD_CV_SL_STATUS_REVIEW(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT)),
+    FORWARD_CV_SL_STATUS_READY_TO_TRANSLATE(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT)),
+    FORWARD_CV_SL_STATUS_PUBLISH(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT)),
+    FORWARD_CV_TL_STATUS_REVIEW(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
+    FORWARD_CV_TL_STATUS_READY_TO_PUBLISH(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
     // FORWARD_CV_TL_STATUS_PUBLISH( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_TL))),
-    CREATE_CODE( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT))),
-    EDIT_CODE( new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT))),
-    REORDER_CODE(new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT))),
-    DEPRECATE_CODE(new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT))),
-    DELETE_CODE(new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT))),
-    ADD_TL_CODE(new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
-    EDIT_TL_CODE(new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
-    DELETE_TL_CODE(new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT))),
-    CREATE_NEW_CV_SL_VERSION(new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT))),
-    CREATE_NEW_CV_TL_VERSION(new HashSet<>(Arrays.asList(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)));
+    CREATE_CODE(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT)),
+    EDIT_CODE(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT)),
+    REORDER_CODE(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT)),
+    DEPRECATE_CODE(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT)),
+    DELETE_CODE(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT)),
+    ADD_TL_CODE(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
+    EDIT_TL_CODE(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
+    DELETE_TL_CODE(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT)),
+    CREATE_NEW_CV_SL_VERSION(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_SL, AgencyRole.ADMIN_CONTENT)),
+    CREATE_NEW_CV_TL_VERSION(EnumSet.of(AgencyRole.ADMIN, AgencyRole.ADMIN_TL, AgencyRole.ADMIN_CONTENT));
 
-    private final Set<AgencyRole> agencyRoles;
+    private final EnumSet<AgencyRole> agencyRoles;
 
-    ActionType(Set<AgencyRole> agencyRoles) {
-        this.agencyRoles = Collections.unmodifiableSet(agencyRoles);
+    ActionType(EnumSet<AgencyRole> agencyRoles) {
+        this.agencyRoles = agencyRoles;
     }
 
     /**

--- a/src/main/java/eu/cessda/cvs/security/UserDetails.java
+++ b/src/main/java/eu/cessda/cvs/security/UserDetails.java
@@ -45,7 +45,7 @@ public class UserDetails extends org.springframework.security.core.userdetails.U
         if (!(o instanceof UserDetails)) {
             return false;
         }
-        return user != null && user.getId().equals(((UserDTO) o).getId());
+        return user != null && user.getId().equals(((UserDetails) o).user.getId());
     }
 
     @Override

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -15,7 +15,7 @@
 
 logging:
   level:
-    ROOT: INFO
+    ROOT: WARN
     io.github.jhipster: INFO
     eu.cessda.cvs: INFO
     com.itextpdf: ERROR


### PR DESCRIPTION
To reduce noise in logs on production, the root level should be set to WARN. The logging level for `eu.cessda.cvs` has not been changed.

This PR also converts ActionType to use an EnumSet rather than a HashSet to store the roles, as for enums EnumSets are a more compact representation as well as faster in most operations.

The set returned by `Language.getCapitalizedIsos()` is now cached.
