### PR TITLE
#571 - skipping checkbox initialization for versions outside of the m…

### DIFF
--- a/src/main/webapp/app/shared/vocabulary-download/vocabulary-download.component.ts
+++ b/src/main/webapp/app/shared/vocabulary-download/vocabulary-download.component.ts
@@ -61,6 +61,9 @@ export class VocabularyDownloadComponent implements OnInit, AfterViewInit {
     const languages: string[] = this.getUniqueVersionLangs();
     for (let i = 0; i < languages.length; i++) {
       const versions: IVersion[] = this.getVersionsByLang(languages[i]);
+      if (!versions[0].number!.startsWith(this.getSlMajorMinorVersionNumber(this.slVersionNumber))) {
+        continue;
+      }
       this.downloadCheckboxes[i] = languages[i] + '-' + versions[0].number;
       this.skosSelected[i] = true;
       this.pdfSelected[i] = true;


### PR DESCRIPTION
this is [the same condition](https://github.com/cessda/cessda.cvs.two/blob/e4c2505665474124a1ed205493609604daef3898/src/main/webapp/app/shared/vocabulary-download/vocabulary-download.component.html#L45) as in the UI