### PR TITLE
Update Java to version 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         stage('Pull SDK Docker Image') {
             agent {
                 docker {
-                    image 'maven:3-jdk-11'
+                    image 'eclipse-temurin:11'
                     reuseNode true
                 }
             }
@@ -49,7 +49,7 @@ pipeline {
                 }
                 stage('Record Issues') {
                     steps {
-                        recordIssues aggregatingResults: true, tools: [errorProne(), java()]
+                        recordIssues aggregatingResults: true, tools: [java()]
                     }
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <properties>
         <!-- Build properties -->
         <maven.version>3.3.9</maven.version>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <node.version>v14.21.3</node.version>
         <npm.version>6.14.18</npm.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This updates the bulding Docker image and configures `javac` to compile source as Java 11, enabling the use of features introduced since Java 8.