### PR TITLE
Revert "Bump springfox.version from 2.9.2 to 2.10.5"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <!-- Exclude Resources, especially Thymeleaf template files that have same structure, but different styling -->
         <!-- Exclude Web app content, where static CVs in JSON files stored -->
         <sonar.exclusions>src/main/resources/**/*,src/main/webapp/content/**/*</sonar.exclusions>
-        <springfox.version>2.10.5</springfox.version>
+        <springfox.version>2.9.2</springfox.version>
         <jjwt.version>0.11.5</jjwt.version>
     </properties>
 


### PR DESCRIPTION
SpringFox 2.10 is not compatible with CVS

> An attempt was made to call a method that does not exist. The attempt was made from the following location:
> 
> `io.github.jhipster.config.apidoc.customizer.JHipsterSwaggerCustomizer.customize(JHipsterSwaggerCustomizer.java:89)`
> 
> The following method did not exist:
> 
> `com.google.common.base.Predicate springfox.documentation.builders.PathSelectors.regex(java.lang.String)`
> 
> The method's class, springfox.documentation.builders.PathSelectors, is available from the following locations:
> 
> `jar:file:/home/stevo/.m2/repository/io/springfox/springfox-core/2.10.5/springfox-core-2.10.5.jar!/springfox/documentation/builders/PathSelectors.class`
> 
> It was loaded from the following location:
> 
> `file:/home/stevo/.m2/repository/io/springfox/springfox-core/2.10.5/springfox-core-2.10.5.jar`
> 
> Action:
> Correct the classpath of your application so that it contains a single, compatible version of `springfox.documentation.builders.PathSelectors`

Reverts cessda/cessda.cvs.two#656. Resolves #685.