### PR TITLE
Fix presence of NUL characters/empty bytes in various export types (SKOS, PDF, HTML)

### DIFF
--- a/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
@@ -37,7 +37,7 @@ import io.github.jhipster.web.util.PaginationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -870,7 +870,7 @@ public class EditorResource {
         AccessibleByteArrayOutputStream outputStream = new AccessibleByteArrayOutputStream();
         String fileName = vocabularyService.generateVocabularyEditorFileDownload( cv, v, lv, ExportService.DownloadType.SKOS, ResourceUtils.getURLWithContextPath(request), outputStream );
 
-        ByteArrayResource resource = new ByteArrayResource(outputStream.getBuffer());
+        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName);
         return ResponseEntity.ok()
@@ -896,7 +896,7 @@ public class EditorResource {
         AccessibleByteArrayOutputStream outputStream = new AccessibleByteArrayOutputStream();
         String fileName = vocabularyService.generateVocabularyEditorFileDownload( cv, v, lv, ExportService.DownloadType.PDF, ResourceUtils.getURLWithContextPath(request), outputStream );
 
-        ByteArrayResource resource = new ByteArrayResource(outputStream.getBuffer());
+        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName);
         return ResponseEntity.ok()
@@ -922,7 +922,7 @@ public class EditorResource {
         AccessibleByteArrayOutputStream outputStream = new AccessibleByteArrayOutputStream();
         String fileName = vocabularyService.generateVocabularyEditorFileDownload( cv, v, lv, ExportService.DownloadType.HTML, ResourceUtils.getURLWithContextPath(request), outputStream );
 
-        ByteArrayResource resource = new ByteArrayResource(outputStream.getBuffer());
+        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName);
         return ResponseEntity.ok()

--- a/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
@@ -36,7 +36,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -780,7 +780,7 @@ public class VocabularyResourceV2 {
         AccessibleByteArrayOutputStream outputStream = new AccessibleByteArrayOutputStream();
         String fileName = vocabularyService.generateVocabularyPublishFileDownload(vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.HTML, requestURL, outputStream);
 
-        ByteArrayResource resource = new ByteArrayResource(outputStream.getBuffer());
+        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName);
         return ResponseEntity.ok()
@@ -808,7 +808,7 @@ public class VocabularyResourceV2 {
         AccessibleByteArrayOutputStream outputStream = new AccessibleByteArrayOutputStream();
         String fileName = vocabularyService.generateVocabularyPublishFileDownload(vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.PDF, requestURL, outputStream );
 
-        ByteArrayResource resource = new ByteArrayResource(outputStream.getBuffer());
+        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName );
         return ResponseEntity.ok()
@@ -826,7 +826,7 @@ public class VocabularyResourceV2 {
         AccessibleByteArrayOutputStream outputStream = new AccessibleByteArrayOutputStream();
         String fileName = vocabularyService.generateVocabularyPublishFileDownload( vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.WORD, requestURL, outputStream );
 
-        ByteArrayResource resource = new ByteArrayResource(outputStream.getBuffer());
+        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName );
         return ResponseEntity.ok().headers(headers).body(resource);
@@ -842,7 +842,7 @@ public class VocabularyResourceV2 {
         AccessibleByteArrayOutputStream outputStream = new AccessibleByteArrayOutputStream();
         String fileName = vocabularyService.generateVocabularyPublishFileDownload( vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.SKOS, requestURL, outputStream );
 
-        ByteArrayResource resource = new ByteArrayResource(outputStream.getBuffer());
+        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName );
         return ResponseEntity.ok().headers(headers).body(resource);

--- a/src/main/java/eu/cessda/cvs/web/rest/utils/AccessibleByteArrayOutputStream.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/utils/AccessibleByteArrayOutputStream.java
@@ -15,7 +15,9 @@
  */
 package eu.cessda.cvs.web.rest.utils;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 
 /**
  * This class implements an output stream in which the data is written into a byte array.
@@ -24,9 +26,9 @@ import java.io.ByteArrayOutputStream;
  */
 public class AccessibleByteArrayOutputStream extends ByteArrayOutputStream {
     /**
-     * Returns the byte array backing this output stream.
+     * Returns an input stream with the contents of the backing byte array.
      */
-    public byte[] getBuffer() {
-        return buf;
+    public InputStream getInputStream() {
+        return new ByteArrayInputStream(buf, 0, count);
     }
 }


### PR DESCRIPTION
AccessibleByteArrayOutputStream used to return the entire backing buffer, but because the buffer is often larger than the data stored within it results in the end of the buffer being empty (or a sequence of NUL characters in ASCII). This is harmless for most export types as the empty bytes won't be referenced, but it does make downloads bigger than they should be.

This closes #702.