### PR TITLE
Build the Angular component in a Node.JS Docker container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         stage('Compile Angular') {
             agent {
                 docker {
-                    image 'node:14'
+                    image 'node:16'
                     reuseNode true
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         stage('Compile Angular') {
             agent {
                 docker {
-                    image 'node:16'
+                    image 'node:14'
                     reuseNode true
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
             stages {
                 stage('Install NPM dependencies') {
                     steps {
-                        configFileProvider([configFile('be684558-5540-4ad6-a155-7c1b4278abc0')]) {
+                        configFileProvider([configFile(fileId: 'be684558-5540-4ad6-a155-7c1b4278abc0', targetLocation: '.npmrc')]) {
                             sh 'npm ci'
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,31 +52,16 @@ pipeline {
                 }
             }
         }
-        stage('JDK') {
+        stage('Compile Java') {
             agent {
                 docker {
                     image 'eclipse-temurin:11'
                     reuseNode true
                 }
             }
-            stages {
-                // Building on main
-                stage('Build Maven Project') {
-                    steps {
-                        withMaven {
-                            sh "./mvnw install -Pci"
-                        }
-                    }
-                    when { branch 'main' }
-                }
-                // Not running on main - test only (for PRs and integration branches)
-                stage('Test Maven Project') {
-                    steps {
-                        withMaven {
-                            sh './mvnw verify -Pci'
-                        }
-                    }
-                    when { not { branch 'main' } }
+            steps {
+                withMaven {
+                    sh "./mvnw verify -Pci"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,8 +20,7 @@ pipeline {
     }
 
     stages {
-        // Building on main
-        stage('Compile Angular') {
+        stage('Node.JS') {
             agent {
                 docker {
                     image 'node:14'
@@ -53,7 +52,7 @@ pipeline {
                 }
             }
         }
-        stage('Compile Java') {
+        stage('JDK') {
             agent {
                 docker {
                     image 'eclipse-temurin:11'
@@ -61,7 +60,8 @@ pipeline {
                 }
             }
             stages {
-                stage('Build Project') {
+                // Building on main
+                stage('Build Maven Project') {
                     steps {
                         withMaven {
                             sh "./mvnw install -Pci"
@@ -70,7 +70,7 @@ pipeline {
                     when { branch 'main' }
                 }
                 // Not running on main - test only (for PRs and integration branches)
-                stage('Test Project') {
+                stage('Test Maven Project') {
                     steps {
                         withMaven {
                             sh './mvnw verify -Pci'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,11 @@ pipeline {
                         }
                     }
                 }
+                stage('Compile Angular') {
+                    steps {
+                        sh 'npm run build-prod'
+                    }
+                }
                 stage('Run Jest tests') {
                     steps {
                         sh 'npm test'
@@ -44,11 +49,6 @@ pipeline {
                         always {
                             junit 'target/test-results/TESTS-results-jest.xml'
                         }
-                    }
-                }
-                stage('Compile Angular') {
-                    steps {
-                        sh 'npm run build-prod'
                     }
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -1043,6 +1043,38 @@
             </properties>
         </profile>
         <profile>
+            <id>ci</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-undertow</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>build-info</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>pl.project13.maven</groupId>
+                        <artifactId>git-commit-id-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <!-- default Spring profiles -->
+                <spring.profiles.active>prod${profile.swagger}</spring.profiles.active>
+            </properties>
+        </profile>
+        <profile>
             <id>war</id>
             <build>
                 <plugins>


### PR DESCRIPTION
The `frontend-maven-plugin` frequently fails to download the Node binary. This PR moves the building of the Angular component to a dedicated Docker image.