### PR TITLE
Feature/455

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -836,6 +836,7 @@
                         <exclude>**/?/**</exclude>
                         <exclude>cvs.jh</exclude>
                         <exclude>src/main/webapp/manifest.webapp</exclude>
+                        <exclude>.config/**</exclude>
                     </excludes>
                     <mapping>
                         <cff>SCRIPT_STYLE</cff>

--- a/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
@@ -1958,6 +1958,7 @@ public class VocabularyServiceImpl implements VocabularyService
             map.put( "docId", uriSl );
             map.put( "docVersionOf", vocabularyDTO.getUri() );
             map.put( "docNotation", vocabularyDTO.getNotation() );
+            map.put( "docSourceLanguage", vocabularyDTO.getSourceLanguage() );
             map.put( "docVersion", versionIncluded.getNumber().toString() );
             map.put( "docLicense", versionIncluded.getLicenseName() );
             map.put( "docLicenseUrl", versionIncluded.getLicenseLink() );

--- a/src/main/resources/templates/xml/export-ddi_rdf.xml
+++ b/src/main/resources/templates/xml/export-ddi_rdf.xml
@@ -27,7 +27,7 @@
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <owl:deprecated th:if="${code.deprecated}" rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean" th:text="${code.deprecated}"></owl:deprecated>
       <skos:inScheme th:attr="'rdf:resource'=${docId}"/>
-      <skos:notation th:text="${code.notation}"></skos:notation>
+      <skos:notation th:attr="'xml:lang'=${docSourceLanguage}" th:text="${code.notation}"></skos:notation>
     <loop th:remove="tag" th:each="version, iterStat: ${versions}">
       <skos:prefLabel th:attr="'xml:lang'=${version.language}" th:text="${code.getTitleByLanguage(version.language)}"></skos:prefLabel>
       <skos:definition th:attr="'xml:lang'=${version.language}" th:text="${code.getDefinitionByLanguage(version.language)}"></skos:definition>

--- a/src/main/resources/templates/xml/export-ddi_rdf.xml
+++ b/src/main/resources/templates/xml/export-ddi_rdf.xml
@@ -6,11 +6,12 @@
 >
    <rdf:Description th:attr="'rdf:about'=${docId}">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
-      <dcterms:isVersionOf th:attr="'rdf:resource'=${docVersionOf}"/>
-      <skos:notation th:text="${docNotation}"></skos:notation>
+      <dcterms:isVersionOf th:attr="'rdf:resource'=${#strings.endsWith(docVersionOf, '/') ? docVersionOf : docVersionOf + '/'}"/>
+      <skos:notation th:attr="'xml:lang'=${docSourceLanguage}" th:text="${docNotation}"></skos:notation>
      <loop th:remove="tag" th:each="version, iterStat: ${versions}">
       <dcterms:title th:attr="'xml:lang'=${version.language}" th:text="${version.title}"></dcterms:title>
       <dcterms:description th:attr="'xml:lang'=${version.language}" th:text="${version.definition}"></dcterms:description>
+      <skos:prefLabel th:attr="'xml:lang'=${version.language}" th:text="${version.title}"></skos:prefLabel>
      </loop>
       <owl:versionInfo th:text="${docVersion}"></owl:versionInfo>
       <dcterms:license th:attr="'rdf:resource'=${docLicenseUrl}"/>


### PR DESCRIPTION
as requested in https://github.com/cessda/cessda.cvs.two/issues/455#issuecomment-1739106299:
- added trailing slash in the `rdf:resource` URI of `dcterms:isVersionOf`'
- added `skos:prefLabel` tag for version
- added `lang` attribute in `skos:notation` tags of version and code