### PR TITLE
Fix various Java compiler warnings

### DIFF
--- a/src/main/java/eu/cessda/cvs/domain/CodeSnippet.java
+++ b/src/main/java/eu/cessda/cvs/domain/CodeSnippet.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CodeSnippet implements Serializable {
+    private static final long serialVersionUID = 2912851169400383645L;
+
     @NotNull
     private ActionType actionType;
     @NotNull

--- a/src/main/java/eu/cessda/cvs/domain/VocabularySnippet.java
+++ b/src/main/java/eu/cessda/cvs/domain/VocabularySnippet.java
@@ -25,6 +25,7 @@ import eu.cessda.cvs.utils.VersionNumber;
 import java.io.Serializable;
 
 public class VocabularySnippet implements Serializable {
+    private static final long serialVersionUID = -2321795469828997616L;
 
     private ActionType actionType;
     private Long agencyId;

--- a/src/main/java/eu/cessda/cvs/domain/search/VocabularyEditor.java
+++ b/src/main/java/eu/cessda/cvs/domain/search/VocabularyEditor.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 @Document(indexName = "vocabularyeditor")
 public class VocabularyEditor extends VocabularyBase {
+    private static final long serialVersionUID = 6335738155427154130L;
 
     @Field( type = FieldType.Keyword )
     private Set<String> statuses;

--- a/src/main/java/eu/cessda/cvs/domain/search/VocabularyPublish.java
+++ b/src/main/java/eu/cessda/cvs/domain/search/VocabularyPublish.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 @Document(indexName = "vocabularypublish")
 public class VocabularyPublish extends VocabularyBase {
+    private static final long serialVersionUID = 1315418060181340404L;
 
     @Field( type = FieldType.Nested, store = true )
     private Set<Code> codes = new HashSet<>();

--- a/src/main/java/eu/cessda/cvs/service/CodeAlreadyExistException.java
+++ b/src/main/java/eu/cessda/cvs/service/CodeAlreadyExistException.java
@@ -16,9 +16,9 @@
 package eu.cessda.cvs.service;
 
 public class CodeAlreadyExistException extends RuntimeException {
+    private static final long serialVersionUID = 3165391114846396394L;
 
-    public CodeAlreadyExistException() {
-        super("Notation already exist!");
+    public CodeAlreadyExistException(String code) {
+        super("Notation " + code + " already exists!");
     }
-
 }

--- a/src/main/java/eu/cessda/cvs/service/InsufficientVocabularyAuthorityException.java
+++ b/src/main/java/eu/cessda/cvs/service/InsufficientVocabularyAuthorityException.java
@@ -16,6 +16,7 @@
 package eu.cessda.cvs.service;
 
 public class InsufficientVocabularyAuthorityException extends RuntimeException {
+    private static final long serialVersionUID = 5885509671807321027L;
 
     public InsufficientVocabularyAuthorityException() {
         super("Authority to access/edit Vocabulary insufficient!");

--- a/src/main/java/eu/cessda/cvs/service/VocabularyAlreadyExistException.java
+++ b/src/main/java/eu/cessda/cvs/service/VocabularyAlreadyExistException.java
@@ -16,9 +16,10 @@
 package eu.cessda.cvs.service;
 
 public class VocabularyAlreadyExistException extends RuntimeException {
+    private static final long serialVersionUID = -5193171904443590121L;
 
-    public VocabularyAlreadyExistException() {
-        super("Vocabulary already exist!");
+    public VocabularyAlreadyExistException(String notation) {
+        super("Vocabulary " + notation + " already exists");
     }
 
 }

--- a/src/main/java/eu/cessda/cvs/service/VocabularyNotFoundException.java
+++ b/src/main/java/eu/cessda/cvs/service/VocabularyNotFoundException.java
@@ -16,10 +16,7 @@
 package eu.cessda.cvs.service;
 
 public class VocabularyNotFoundException extends RuntimeException {
-
-    public VocabularyNotFoundException() {
-        super("Vocabulary not found!");
-    }
+    private static final long serialVersionUID = -399156303999555524L;
 
     public VocabularyNotFoundException(String message) {
         super(message);

--- a/src/main/java/eu/cessda/cvs/service/dto/AgencyDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/AgencyDTO.java
@@ -28,6 +28,7 @@ import java.util.Objects;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AgencyDTO implements Serializable {
+    private static final long serialVersionUID = -1795172177534506127L;
 
     private Long id;
 

--- a/src/main/java/eu/cessda/cvs/service/dto/CodeDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/CodeDTO.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
-
 import eu.cessda.cvs.domain.Code;
 import eu.cessda.cvs.domain.enumeration.Language;
 import eu.cessda.cvs.utils.VersionNumber;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.Lob;
@@ -33,13 +33,12 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.codec.digest.DigestUtils;
-
 /**
  * A DTO for the {@link Code} entity.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CodeDTO implements Serializable {
+    private static final long serialVersionUID = -5916802523668287620L;
 
     private Long id;
 
@@ -1055,7 +1054,7 @@ public class CodeDTO implements Serializable {
     }
 
     public enum HashFunction {
-        
+
         MD2("md2", DigestUtils::md2Hex),
         MD5("md5", DigestUtils::md5Hex),
         SHA1("sha1", DigestUtils::sha1Hex),
@@ -1092,14 +1091,14 @@ public class CodeDTO implements Serializable {
     }
 
     public static String generateHash(HashFunction hf, String str, Integer len) {
-        
+
         // default hash
         String hash = '#' + str;
 
         if (hf != null) {
             hash = hf.getFn().exec(str);
         }
-        
+
         // truncate
         if (len != null && len > 0) {
             hash = hash.substring(0, len);
@@ -1122,7 +1121,7 @@ public class CodeDTO implements Serializable {
         }
 
         Matcher m = patternHashCodeUriPlaceholder.matcher(uri);
-        
+
         while (m.find()) {
             HashFunction hf = HashFunction.fromString(m.group(1));
             Integer len = Integer.parseInt(m.group(2));

--- a/src/main/java/eu/cessda/cvs/service/dto/CommentDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/CommentDTO.java
@@ -24,6 +24,7 @@ import java.util.Objects;
  * A DTO for the {@link eu.cessda.cvs.domain.Comment} entity.
  */
 public class CommentDTO implements Serializable {
+    private static final long serialVersionUID = -3647910600758884671L;
 
     private Long id;
 

--- a/src/main/java/eu/cessda/cvs/service/dto/ConceptDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/ConceptDTO.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ConceptDTO implements Serializable {
-
+    private static final long serialVersionUID = 6393391537097907915L;
 
     private Long id;
 

--- a/src/main/java/eu/cessda/cvs/service/dto/LicenceDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/LicenceDTO.java
@@ -24,6 +24,7 @@ import java.util.Objects;
  * A DTO for the {@link eu.cessda.cvs.domain.Licence} entity.
  */
 public class LicenceDTO implements Serializable {
+    private static final long serialVersionUID = -6758468839650832552L;
 
     private Long id;
 

--- a/src/main/java/eu/cessda/cvs/service/dto/MetadataFieldDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/MetadataFieldDTO.java
@@ -29,6 +29,7 @@ import java.util.Set;
  * A DTO for the {@link eu.cessda.cvs.domain.MetadataField} entity.
  */
 public class MetadataFieldDTO implements Serializable {
+    private static final long serialVersionUID = -8913519673208047626L;
 
     private Long id;
 

--- a/src/main/java/eu/cessda/cvs/service/dto/MetadataValueDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/MetadataValueDTO.java
@@ -25,6 +25,7 @@ import java.util.Objects;
  * A DTO for the {@link eu.cessda.cvs.domain.MetadataValue} entity.
  */
 public class MetadataValueDTO implements Serializable {
+    private static final long serialVersionUID = 504933053033683641L;
 
     private Long id;
 

--- a/src/main/java/eu/cessda/cvs/service/dto/PasswordChangeDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/PasswordChangeDTO.java
@@ -32,7 +32,6 @@ public class PasswordChangeDTO {
     }
 
     public String getCurrentPassword() {
-
         return currentPassword;
     }
 

--- a/src/main/java/eu/cessda/cvs/service/dto/ResolverDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/ResolverDTO.java
@@ -26,6 +26,7 @@ import java.util.Objects;
  * A DTO for the {@link eu.cessda.cvs.domain.Resolver} entity.
  */
 public class ResolverDTO implements Serializable {
+    private static final long serialVersionUID = 2981181894274242634L;
 
     private Long id;
 

--- a/src/main/java/eu/cessda/cvs/service/dto/UserAgencyDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/UserAgencyDTO.java
@@ -25,6 +25,7 @@ import java.util.Objects;
  * A DTO for the {@link eu.cessda.cvs.domain.UserAgency} entity.
  */
 public class UserAgencyDTO implements Serializable {
+    private static final long serialVersionUID = 6683764195118500502L;
 
     private Long id;
 

--- a/src/main/java/eu/cessda/cvs/service/dto/UserDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/UserDTO.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
  * A DTO representing a user, with his authorities.
  */
 public class UserDTO implements Serializable {
+    private static final long serialVersionUID = -3508997745704450197L;
 
     private Long id;
 

--- a/src/main/java/eu/cessda/cvs/service/dto/VersionDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/VersionDTO.java
@@ -48,8 +48,9 @@ import java.util.stream.Collectors;
 @JsonInclude( JsonInclude.Include.NON_NULL )
 public class VersionDTO implements Serializable
 {
+    private static final long serialVersionUID = 6451702494637350395L;
 
-	private Long id;
+    private Long id;
 
 	@NotNull
 	@Size( max = 20 )

--- a/src/main/java/eu/cessda/cvs/service/dto/VocabularyChangeDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/VocabularyChangeDTO.java
@@ -29,6 +29,7 @@ import java.util.Objects;
  * A DTO for the {@link eu.cessda.cvs.domain.VocabularyChange} entity.
  */
 public class VocabularyChangeDTO implements Serializable {
+    private static final long serialVersionUID = 3945898883897497903L;
 
     private Long id;
 

--- a/src/main/java/eu/cessda/cvs/service/dto/VocabularyDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/VocabularyDTO.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class VocabularyDTO implements Serializable {
+    private static final long serialVersionUID = -8464813042927663693L;
 
     private Long id;
 

--- a/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
@@ -517,7 +517,7 @@ public class VocabularyServiceImpl implements VocabularyService
     private Vocabulary createNewVocabulary( VocabularyDTO vocabularyDTO ) {
         // check if Vocabulary already exist for new vocabulary
         if ( vocabularyRepository.existsByNotation( vocabularyDTO.getNotation() ) ) {
-            throw new VocabularyAlreadyExistException();
+            throw new VocabularyAlreadyExistException(vocabularyDTO.getNotation());
         }
 
         // query agency
@@ -591,7 +591,7 @@ public class VocabularyServiceImpl implements VocabularyService
         if ( codeSnippet.getActionType().equals( ActionType.EDIT_CODE ) && !conceptDTO.getNotation().equals( codeSnippet.getNotation() ) ) {
             if ( versionDTO.getConcepts().stream()
                 .anyMatch( c -> c.getNotation().equals( codeSnippet.getNotation() ) ) ) {
-                throw new CodeAlreadyExistException();
+                throw new CodeAlreadyExistException( codeSnippet.getNotation() );
             }
 
             // check if this concept influence parent and child concepts
@@ -679,9 +679,8 @@ public class VocabularyServiceImpl implements VocabularyService
             vocabularyDTO.getAgencyId(), versionDTO.getLanguage() );
 
         // check if concept already exist for new concept
-        if ( versionDTO.getConcepts().stream()
-            .anyMatch( c -> c.getNotation().equals( codeSnippet.getNotation() ) ) ) {
-            throw new CodeAlreadyExistException();
+        if ( versionDTO.getConcepts().stream().anyMatch( c -> c.getNotation().equals( codeSnippet.getNotation() ) ) ) {
+            throw new CodeAlreadyExistException( codeSnippet.getNotation() );
         }
         // ==> #349: calculate code position at the server side instead of the client side
         Integer refConceptPos = getConceptPositionById( codeSnippet.getInsertionRefConceptId(), versionDTO.getConcepts() );

--- a/src/main/java/eu/cessda/cvs/service/mapper/AgencyMapper.java
+++ b/src/main/java/eu/cessda/cvs/service/mapper/AgencyMapper.java
@@ -31,7 +31,12 @@ public interface AgencyMapper extends EntityMapper<AgencyDTO, Agency> {
     @Mapping(target = "removeUserAgency", ignore = true)
     Agency toEntity(AgencyDTO agencyDTO);
 
-    default Agency fromId(Long id) {
+    @Mapping( target = "logo", ignore = true )
+    @Mapping( target = "deletable", ignore = true )
+    @Mapping( target = "copyright", ignore = true )
+    AgencyDTO toDto( Agency entity );
+
+    default Agency fromId( Long id) {
         if (id == null) {
             return null;
         }

--- a/src/main/java/eu/cessda/cvs/service/mapper/CodeMapper.java
+++ b/src/main/java/eu/cessda/cvs/service/mapper/CodeMapper.java
@@ -26,6 +26,9 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring", uses = {})
 public interface CodeMapper extends EntityMapper<CodeDTO, Code> {
 
+    @Mapping( target = "replacedByUri", ignore = true )
+    @Mapping( target = "replacedByNotation", ignore = true )
+    @Mapping( target = "replacedById", ignore = true )
     @Mapping(source = "languages", target = "languages")
     @Mapping(source = "deprecated", target = "deprecated")
     CodeDTO toDto(Code code);

--- a/src/main/java/eu/cessda/cvs/service/mapper/MetadataFieldMapper.java
+++ b/src/main/java/eu/cessda/cvs/service/mapper/MetadataFieldMapper.java
@@ -18,6 +18,7 @@ package eu.cessda.cvs.service.mapper;
 import eu.cessda.cvs.domain.MetadataField;
 import eu.cessda.cvs.service.dto.MetadataFieldDTO;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 /**
  * Mapper for the entity {@link MetadataField} and its DTO {@link MetadataFieldDTO}.
@@ -25,7 +26,13 @@ import org.mapstruct.Mapper;
 @Mapper(componentModel = "spring", uses = {MetadataValueMapper.class})
 public interface MetadataFieldMapper extends EntityMapper<MetadataFieldDTO, MetadataField> {
 
-    default MetadataField fromId(Long id) {
+    @Mapping( target = "removeMetadataValue", ignore = true )
+    MetadataField toEntity( MetadataFieldDTO dto );
+
+    @Mapping( target = "removeMetadataValue", ignore = true )
+    MetadataFieldDTO toDto( MetadataField entity );
+
+    default MetadataField fromId( Long id) {
         if (id == null) {
             return null;
         }

--- a/src/main/java/eu/cessda/cvs/service/mapper/UserAgencyMapper.java
+++ b/src/main/java/eu/cessda/cvs/service/mapper/UserAgencyMapper.java
@@ -28,9 +28,12 @@ public interface UserAgencyMapper extends EntityMapper<UserAgencyDTO, UserAgency
 
     @Mapping(source = "agency.id", target = "agencyId")
     @Mapping(source = "agency.name", target = "agencyName")
+    @Mapping(source = "user.id", target = "userId")
     UserAgencyDTO toDto(UserAgency userAgency);
 
     @Mapping(source = "agencyId", target = "agency")
+    // @Mapping(source = "userId", target = "user") - TODO: should this be mapped?
+    @Mapping(target = "user", ignore = true)
     UserAgency toEntity(UserAgencyDTO userAgencyDTO);
 
     default UserAgency fromId(Long id) {

--- a/src/main/java/eu/cessda/cvs/service/mapper/VersionMapper.java
+++ b/src/main/java/eu/cessda/cvs/service/mapper/VersionMapper.java
@@ -26,9 +26,11 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring", uses = {VocabularyMapper.class, ConceptMapper.class, CommentMapper.class})
 public interface VersionMapper extends EntityMapper<VersionDTO, Version> {
 
+    // TODO: evaluate these mappings
     @Mapping(source = "vocabulary.id", target = "vocabularyId")
     VersionDTO toDto(Version version);
 
+    @Mapping(target = "removeComment", ignore = true)
     @Mapping(target = "removeConcept", ignore = true)
     @Mapping(source = "vocabularyId", target = "vocabulary")
     Version toEntity(VersionDTO versionDTO);

--- a/src/main/java/eu/cessda/cvs/service/mapper/VocabularyEditorMapper.java
+++ b/src/main/java/eu/cessda/cvs/service/mapper/VocabularyEditorMapper.java
@@ -26,6 +26,7 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring", uses = {CodeMapper.class})
 public interface VocabularyEditorMapper extends EntityMapper<VocabularyDTO, VocabularyEditor> {
 
+    // TODO: evaluate these mappings
     @Mapping(source = "codes", target = "codes")
     @Mapping(source = "languages", target = "languages")
     @Mapping(source = "statuses", target = "statuses")

--- a/src/main/java/eu/cessda/cvs/service/mapper/VocabularyMapper.java
+++ b/src/main/java/eu/cessda/cvs/service/mapper/VocabularyMapper.java
@@ -19,6 +19,7 @@ import eu.cessda.cvs.domain.Vocabulary;
 import eu.cessda.cvs.service.dto.VocabularyDTO;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
 /**
@@ -27,9 +28,11 @@ import org.mapstruct.MappingTarget;
 @Mapper(componentModel = "spring", uses = {VersionMapper.class})
 public interface VocabularyMapper extends EntityMapper<VocabularyDTO, Vocabulary> {
 
+    // TODO: evaluate these mappings
     VocabularyDTO toDto(Vocabulary vocabulary);
 
-    Vocabulary toEntity(VocabularyDTO vocabularyDTO);
+    @Mapping( target = "removeVersion", ignore = true )
+    Vocabulary toEntity( VocabularyDTO vocabularyDTO);
 
     @AfterMapping
     default void setTitleAll(@MappingTarget VocabularyDTO vocabularyDTO) {

--- a/src/main/java/eu/cessda/cvs/service/mapper/VocabularyPublishMapper.java
+++ b/src/main/java/eu/cessda/cvs/service/mapper/VocabularyPublishMapper.java
@@ -25,6 +25,8 @@ import org.mapstruct.Mapping;
  */
 @Mapper(componentModel = "spring", uses = {CodeMapper.class})
 public interface VocabularyPublishMapper extends EntityMapper<VocabularyDTO, VocabularyPublish> {
+
+    // TODO: evaluate these mappings
     @Mapping(source = "codes", target = "codes")
     @Mapping(source = "languagesPublished", target = "languagesPublished")
     VocabularyDTO toDto(VocabularyPublish vocabulary);

--- a/src/main/java/eu/cessda/cvs/service/search/EsFilter.java
+++ b/src/main/java/eu/cessda/cvs/service/search/EsFilter.java
@@ -22,7 +22,9 @@ import java.util.List;
 import java.util.Map;
 
 public class EsFilter implements Serializable {
-	public enum FilterType {KEYWORD, RANGE}
+    private static final long serialVersionUID = -3650519521378103904L;
+
+    public enum FilterType {KEYWORD, RANGE}
 
     public static final String AGENCY_AGG = "agencyName";
     public static final String LANGS_AGG = "languages";

--- a/src/main/java/eu/cessda/cvs/service/search/EsQueryResultDetail.java
+++ b/src/main/java/eu/cessda/cvs/service/search/EsQueryResultDetail.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Optional;
 
 public class EsQueryResultDetail implements Serializable {
+    private static final long serialVersionUID = -4522175739918034968L;
+
 	public static final int PAGE_SIZE = 30 ;
     private SearchScope searchScope;
 

--- a/src/main/java/eu/cessda/cvs/utils/VersionNumberJavaDescriptor.java
+++ b/src/main/java/eu/cessda/cvs/utils/VersionNumberJavaDescriptor.java
@@ -20,6 +20,7 @@ import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
 import org.hibernate.type.descriptor.java.ImmutableMutabilityPlan;
 
 public class VersionNumberJavaDescriptor extends AbstractTypeDescriptor<VersionNumber> {
+    private static final long serialVersionUID = 3118219910023942818L;
 
     public static final VersionNumberJavaDescriptor INSTANCE = new VersionNumberJavaDescriptor();
 

--- a/src/main/java/eu/cessda/cvs/utils/VersionNumberType.java
+++ b/src/main/java/eu/cessda/cvs/utils/VersionNumberType.java
@@ -15,13 +15,13 @@
  */
 package eu.cessda.cvs.utils;
 
-import org.hibernate.HibernateException;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.type.AbstractSingleColumnStandardBasicType;
 import org.hibernate.type.LiteralType;
 import org.hibernate.type.descriptor.sql.VarcharTypeDescriptor;
 
 public class VersionNumberType extends AbstractSingleColumnStandardBasicType<VersionNumber> implements LiteralType<VersionNumber> {
+    private static final long serialVersionUID = 948974996070167502L;
 
     public static final VersionNumberType INSTANCE = new VersionNumberType();
 
@@ -30,7 +30,7 @@ public class VersionNumberType extends AbstractSingleColumnStandardBasicType<Ver
     }
 
     @Override
-    public String toString(VersionNumber value) throws HibernateException {
+    public String toString(VersionNumber value) {
         return value.toString();
     }
 
@@ -45,7 +45,7 @@ public class VersionNumberType extends AbstractSingleColumnStandardBasicType<Ver
     }
 
     @Override
-	public String objectToSQLString(VersionNumber value, Dialect dialect) throws Exception {
+	public String objectToSQLString(VersionNumber value, Dialect dialect) {
 		return "{d '" + value.toString() + "'}";
 	}
 }

--- a/src/main/java/eu/cessda/cvs/web/rest/AccountResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/AccountResource.java
@@ -28,19 +28,15 @@ import eu.cessda.cvs.web.rest.errors.InvalidPasswordException;
 import eu.cessda.cvs.web.rest.errors.LoginAlreadyUsedException;
 import eu.cessda.cvs.web.rest.vm.KeyAndPasswordVM;
 import eu.cessda.cvs.web.rest.vm.ManagedUserVM;
-
 import org.apache.commons.lang3.StringUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-
 import java.util.Optional;
 
 /**
@@ -53,8 +49,9 @@ public class AccountResource {
     @Autowired
     private AuditEventPublisher auditPublisher;
 
-    private static class AccountResourceException extends RuntimeException {
-        private AccountResourceException(String message) {
+    public static class AccountResourceException extends RuntimeException {
+        private static final long serialVersionUID = -6612174679532316605L;
+        public AccountResourceException( String message ) {
             super(message);
         }
     }
@@ -68,7 +65,6 @@ public class AccountResource {
     private final MailService mailService;
 
     public AccountResource(UserRepository userRepository, UserService userService, MailService mailService) {
-
         this.userRepository = userRepository;
         this.userService = userService;
         this.mailService = mailService;
@@ -151,7 +147,7 @@ public class AccountResource {
         }
         userService.updateUser(userDTO.getFirstName(), userDTO.getLastName(), userDTO.getEmail(),
             userDTO.getLangKey(), userDTO.getImageUrl());
-        
+
         //notify the auditing mechanism
         String auditUserString = "";
         Optional<String> auditUser = SecurityUtils.getCurrentUserLogin();

--- a/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
@@ -33,13 +33,10 @@ import eu.cessda.cvs.web.rest.domain.CvResult;
 import eu.cessda.cvs.web.rest.errors.BadRequestAlertException;
 import eu.cessda.cvs.web.rest.utils.AccessibleByteArrayOutputStream;
 import eu.cessda.cvs.web.rest.utils.ResourceUtils;
-
 import io.github.jhipster.web.util.HeaderUtil;
 import io.github.jhipster.web.util.PaginationUtil;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.InputStreamResource;
@@ -55,16 +52,11 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import javax.persistence.EntityNotFoundException;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -178,7 +170,7 @@ public class EditorResource {
     public ResponseEntity<VersionDTO> createNewVocabularyVersion(@PathVariable Long id) {
         log.debug("REST request to create new Vocabulary with version ID: {}", id);
         VersionDTO result = vocabularyService.createNewVersion(id);
-        
+
         //notify the auditing mechanism
         String auditUserString = "";
         Optional<String> auditUser = SecurityUtils.getCurrentUserLogin();
@@ -258,7 +250,7 @@ public class EditorResource {
             auditUserString = auditUser.get();
         }
         auditPublisher.publish(auditUserString, vocabularyDTO, versionDTO, vocabularySnippet, vocabularySnippet.getActionType().name(), true);
-        
+
         return ResponseEntity.ok()
             .headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_VERSION_NAME, versionDTO.getNotation()))
             .body(versionDTO);
@@ -418,7 +410,7 @@ public class EditorResource {
         }
 
         ConceptDTO result = vocabularyService.saveCode(codeSnippet);
-        
+
         //notify the auditing mechanism
         VersionDTO versionDTO = versionService.findOne(codeSnippet.getVersionId())
             .orElseThrow(() -> new EntityNotFoundException(UNABLE_TO_FIND_VERSION + codeSnippet.getVersionId()));
@@ -482,7 +474,7 @@ public class EditorResource {
                 if (conceptDTO != null) {
                     conceptDTO.setTitle(codeSnippet.getTitle());
                     conceptDTO.setDefinition(codeSnippet.getDefinition());
-                    
+
                     //notify the auditing mechanism
                     String auditUserString = "";
                     Optional<String> auditUser = SecurityUtils.getCurrentUserLogin();
@@ -523,7 +515,7 @@ public class EditorResource {
         // check if concept already exist for new concept
         if (versionDTO.getConcepts().stream()
             .anyMatch(c -> c.getNotation().equals(codeSnippet.getNotation()))) {
-            throw new CodeAlreadyExistException();
+            throw new CodeAlreadyExistException(codeSnippet.getNotation());
         }
         // set position if not available
         if (codeSnippet.getPosition() == null)
@@ -532,11 +524,7 @@ public class EditorResource {
         ConceptDTO newConceptDTO = new ConceptDTO(codeSnippet);
 
         //notify the auditing mechanism
-        String auditUserString = "";
-        Optional<String> auditUser = SecurityUtils.getCurrentUserLogin();
-        if (auditUser.isPresent()) {
-            auditUserString = auditUser.get();
-        }
+        String auditUserString = SecurityUtils.getCurrentUserLogin().orElse( "" );
         auditPublisher.publish(auditUserString, null, versionDTO, newConceptDTO, null, codeSnippet, "CREATE_CODE");
 
         // add concept to version and save version to save new concept
@@ -690,7 +678,7 @@ public class EditorResource {
             auditUserString = auditUser.get();
         }
         auditPublisher.publish(auditUserString, vocabularyDTO, versionDTO, conceptDTO, null, null, ActionType.DELETE_CODE.name());
-        
+
         // remove parent-child link and save, orphan concept will be automatically deleted
         versionDTO.removeConcept(conceptDTO);
 
@@ -742,7 +730,7 @@ public class EditorResource {
             .orElseThrow(() -> new EntityNotFoundException(UNABLE_TO_FIND_VERSION + codeSnippet.getVersionId() ));
         VocabularyDTO vocabularyDTO = vocabularyService.findOne(versionDTO.getVocabularyId())
             .orElseThrow( () -> new EntityNotFoundException(UNABLE_TO_FIND_VOCABULARY + versionDTO.getVocabularyId() ));
-        
+
         //notify the auditing mechanism
         ConceptDTO conceptDTO = conceptService.findOne(codeSnippet.getConceptId())
             .orElseThrow(() -> new EntityNotFoundException(UNABLE_TO_FIND_CONCEPT + codeSnippet.getConceptId()));
@@ -890,7 +878,7 @@ public class EditorResource {
             .orElseThrow(() -> new EntityNotFoundException(UNABLE_TO_FIND_VERSION + commentDTO.getId() ));
         commentDTO.setVersionId( null );
         versionDTO.removeComment(commentDTO);
-        
+
         //notify the auditing mechanism
         String auditUserString = "";
         Optional<String> auditUser = SecurityUtils.getCurrentUserLogin();
@@ -898,7 +886,7 @@ public class EditorResource {
             auditUserString = auditUser.get();
         }
         auditPublisher.publish(auditUserString, versionDTO, commentDTO, "DELETE_COMMENT");
-        
+
         // automatically remove comment
         versionService.save(versionDTO);
 

--- a/src/main/java/eu/cessda/cvs/web/rest/domain/Aggr.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/domain/Aggr.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 
 public class Aggr implements Serializable {
+    private static final long serialVersionUID = -7907701690323224787L;
+
     private String type;
     private String field;
     private List<String> values = new ArrayList<>();

--- a/src/main/java/eu/cessda/cvs/web/rest/domain/Bucket.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/domain/Bucket.java
@@ -18,6 +18,8 @@ package eu.cessda.cvs.web.rest.domain;
 import java.io.Serializable;
 
 public class Bucket implements Serializable {
+    private static final long serialVersionUID = -103627179503698977L;
+
     private String k;
     private Long v;
 

--- a/src/main/java/eu/cessda/cvs/web/rest/domain/CvResult.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/domain/CvResult.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CvResult implements Serializable {
+    private static final long serialVersionUID = 1607897901898491262L;
+
     private List<VocabularyDTO> vocabularies;
     private long totalElements;
     private int totalPage;

--- a/src/main/java/eu/cessda/cvs/web/rest/domain/Maintenance.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/domain/Maintenance.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
 
 public class Maintenance implements Serializable {
     private static final long serialVersionUID = 1L;
+
     private String output;
     private LocalDateTime timestamp;
     private String type;

--- a/src/main/java/eu/cessda/cvs/web/rest/domain/SimpleResponse.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/domain/SimpleResponse.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 
 public class SimpleResponse implements Serializable {
     private static final long serialVersionUID = 1L;
+    
     private String status;
     private String message;
 

--- a/src/main/java/eu/cessda/cvs/web/rest/vm/ManagedUserVM.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/vm/ManagedUserVM.java
@@ -23,6 +23,7 @@ import javax.validation.constraints.Size;
  * View Model extending the UserDTO, which is meant to be used in the user management UI.
  */
 public class ManagedUserVM extends UserDTO {
+    private static final long serialVersionUID = -951514693943180002L;
 
     public static final int PASSWORD_MIN_LENGTH = 4;
 


### PR DESCRIPTION
Most of the warnings were caused by `Serializable` classes missing `serialVersionUID` fields. Others were caused by missing Mapstruct mappings. Some Mapstruct warnings are still emitted as there is a case to be made that the mappings are incomplete.

`CodeAlreadyExistException` and `VocabularyAlreadyExistException` have been modified so that the code or the vocabulary that exists is now reported.

This closes #346. See #805 for details about the missing Mapstruct mappings.