### PR TITLE
Use the V8 coverage provider to gather coverage in Jest tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                 }
                 stage('Run Jest tests') {
                     steps {
-                        sh 'npm test'
+                        sh 'npm test -- --coverage'
                     }
                     post {
                         always {

--- a/src/test/javascript/jest.conf.js
+++ b/src/test/javascript/jest.conf.js
@@ -21,6 +21,7 @@ module.exports = {
     setupFilesAfterEnv: ['<rootDir>/src/test/javascript/jest.ts'],
     cacheDirectory: '<rootDir>/target/jest-cache',
     coverageDirectory: '<rootDir>/target/test-results/',
+    coverageProvider: 'v8',
     globals: {
         'ts-jest': {
             stringifyContentPathRegex: '\\.html$',
@@ -48,7 +49,7 @@ function mapTypescriptAliasToJestAlias(alias = {}) {
         return jestAliases;
     }
     Object.entries(tsconfig.compilerOptions.paths)
-        .filter(([key, value]) => {
+        .filter(([_key, value]) => {
             // use Typescript alias in Jest only if this has value
             if (value.length) {
                 return true;


### PR DESCRIPTION
The V8 coverage provider uses significantly less memory than the Babel coverage provider. This prevents OOM errors when running Jest tests on Jenkins.