### PR TITLE
Convert some requests that return HTTP 500 to return HTTP 400 codes instead

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
                 withMaven {
                     sh "./mvnw jib:build -Pci -Djib.to.image=${IMAGE_TAG}"
                 }
-                sh "gcloud container images add-tag ${IMAGE_TAG} ${DOCKER_ARTIFACT_REGISTRY}/${productName}-${componentName}:${env.BRANCH_NAME}-latest"
+                sh "gcloud artifacts docker tags add ${IMAGE_TAG} ${DOCKER_ARTIFACT_REGISTRY}/${productName}-${componentName}:${env.BRANCH_NAME}-latest"
             }
             when { branch 'main' }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -385,18 +385,11 @@
             <groupId>org.docx4j</groupId>
             <artifactId>docx4j-ImportXHTML</artifactId>
             <version>8.3.8</version>
-            <exclusions>
-                <!-- Exclude import of DOCX4J -->
-                <exclusion>
-                    <groupId>org.docx4j</groupId>
-                    <artifactId>docx4j-JAXB-ReferenceImpl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.docx4j</groupId>
-            <artifactId>docx4j-JAXB-ReferenceImpl</artifactId>
-            <version>8.3.9</version>
+            <groupId>com.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-slf4j</artifactId>
+            <version>1.0.10</version>
         </dependency>
         <dependency>
             <groupId>org.imgscalr</groupId>

--- a/src/main/java/eu/cessda/cvs/config/LoggingConfiguration.java
+++ b/src/main/java/eu/cessda/cvs/config/LoggingConfiguration.java
@@ -18,6 +18,7 @@ package eu.cessda.cvs.config;
 import ch.qos.logback.classic.LoggerContext;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openhtmltopdf.slf4j.Slf4jLogger;
 import io.github.jhipster.config.JHipsterProperties;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -61,5 +62,8 @@ public class LoggingConfiguration {
         if (jHipsterProperties.getMetrics().getLogs().isEnabled()) {
             setMetricsMarkerLogbackFilter(context, loggingProperties.isUseJsonFormat());
         }
+
+        // Configure openhtmltopdf logging
+        com.openhtmltopdf.util.XRLog.setLoggerImpl( new Slf4jLogger() );
     }
 }

--- a/src/main/java/eu/cessda/cvs/service/IllegalActionTypeException.java
+++ b/src/main/java/eu/cessda/cvs/service/IllegalActionTypeException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017-2023 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.cessda.cvs.service;
+
+import eu.cessda.cvs.security.ActionType;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class IllegalActionTypeException extends Exception
+{
+    private static final long serialVersionUID = 2825945650155639246L;
+
+    public IllegalActionTypeException()
+    {
+        super( "Missing action type" );
+    }
+
+    public IllegalActionTypeException( ActionType actionType )
+    {
+        super( String.format( "Action type %s not supported", actionType ));
+    }
+
+    public IllegalActionTypeException( ActionType actionType, HttpMethod method )
+    {
+        super( String.format( "Illegal action type %s for method %s", actionType, method ) );
+    }
+}

--- a/src/main/java/eu/cessda/cvs/service/MissingIdentifierException.java
+++ b/src/main/java/eu/cessda/cvs/service/MissingIdentifierException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017-2023 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.cessda.cvs.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class MissingIdentifierException extends RuntimeException
+{
+    private static final long serialVersionUID = -5278158330435765412L;
+
+    public MissingIdentifierException( String message)
+    {
+        super( message );
+    }
+}

--- a/src/main/java/eu/cessda/cvs/service/VocabularyService.java
+++ b/src/main/java/eu/cessda/cvs/service/VocabularyService.java
@@ -278,5 +278,5 @@ public interface VocabularyService {
      * @param vocabularySnippet
      * @return
      */
-    VersionDTO forwardStatus(VocabularySnippet vocabularySnippet);
+    VersionDTO forwardStatus(VocabularySnippet vocabularySnippet) throws IllegalActionTypeException;
 }

--- a/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
@@ -553,7 +553,7 @@ public class VocabularyServiceImpl implements VocabularyService
      */
     @Override
     public ConceptDTO saveCode( CodeSnippet codeSnippet ) {
-        // if we add code we need to ensure that it will be clonned to every TL probably as the workflow had been changed!!!
+        // if we add code we need to ensure that it will be cloned to every TL probably as the workflow had been changed!!!
         log.debug( "Request to save Concept and Version from CodeSnippet : {}", codeSnippet.getConceptId() );
         ConceptDTO conceptDTO = null;
         // get version
@@ -568,21 +568,28 @@ public class VocabularyServiceImpl implements VocabularyService
         VocabularyDTO vocabularyDTO = findOne( versionDTO.getVocabularyId() )
             .orElseThrow( () -> new EntityNotFoundException( UNABLE_FIND_VOCABULARY + versionDTO.getVocabularyId() ) );
 
-        if ( codeSnippet.getActionType().equals( ActionType.CREATE_CODE ) ) {
-            conceptDTO = createCode( codeSnippet, versionDTO, vocabularyDTO );
-        } else if ( codeSnippet.getActionType().equals( ActionType.EDIT_CODE ) ||
-            codeSnippet.getActionType().equals( ActionType.ADD_TL_CODE ) ||
-            codeSnippet.getActionType().equals( ActionType.EDIT_TL_CODE ) ||
-            codeSnippet.getActionType().equals( ActionType.DELETE_TL_CODE ) ) {
-            conceptDTO = editCode( codeSnippet, versionDTO, vocabularyDTO );
+        switch ( codeSnippet.getActionType() )
+        {
+            case CREATE_CODE:
+                conceptDTO = createCode( codeSnippet, versionDTO, vocabularyDTO );
+                break;
+            case EDIT_CODE:
+            case ADD_TL_CODE:
+            case EDIT_TL_CODE:
+            case DELETE_TL_CODE:
+                conceptDTO = editCode( codeSnippet, versionDTO, vocabularyDTO );
+                break;
+            default:
+                break;
         }
+
         return conceptDTO;
     }
 
     private ConceptDTO editCode( CodeSnippet codeSnippet, VersionDTO versionDTO, VocabularyDTO vocabularyDTO ) {
         ConceptDTO conceptDTO;
         // check for authorization
-        checkEditCodeAuthorization( codeSnippet, versionDTO, vocabularyDTO );
+        SecurityUtils.checkResourceAuthorization( codeSnippet.getActionType(), vocabularyDTO.getAgencyId(), versionDTO.getLanguage() );
         // get concept from versionDTO
         conceptDTO = versionDTO.getConcepts().stream().filter( c -> c.getId().equals( codeSnippet.getConceptId() ) ).findFirst()
             .orElseThrow( () -> new EntityNotFoundException( "Unable to find concept with Id " + codeSnippet.getConceptId() ) );
@@ -606,14 +613,20 @@ public class VocabularyServiceImpl implements VocabularyService
             conceptDTO.setNotation( codeSnippet.getNotation() );
         }
 
-        if ( codeSnippet.getActionType().equals( ActionType.EDIT_CODE ) ||
-            codeSnippet.getActionType().equals( ActionType.ADD_TL_CODE ) ||
-            codeSnippet.getActionType().equals( ActionType.EDIT_TL_CODE ) ) {
-            conceptDTO.setTitle( codeSnippet.getTitle() );
-            conceptDTO.setDefinition( codeSnippet.getDefinition() );
-        } else if ( codeSnippet.getActionType().equals( ActionType.DELETE_TL_CODE ) ) {
-            conceptDTO.setTitle( null );
-            conceptDTO.setDefinition( null );
+        switch ( codeSnippet.getActionType() )
+        {
+            case EDIT_CODE:
+            case ADD_TL_CODE:
+            case EDIT_TL_CODE:
+                conceptDTO.setTitle( codeSnippet.getTitle() );
+                conceptDTO.setDefinition( codeSnippet.getDefinition() );
+                break;
+            case DELETE_TL_CODE:
+                conceptDTO.setTitle( null );
+                conceptDTO.setDefinition( null );
+                break;
+            default:
+                break;
         }
 
         // save versionDTO together with concepts
@@ -646,21 +659,6 @@ public class VocabularyServiceImpl implements VocabularyService
                 versionDTO.getVocabularyId() );
             vocabularyChangeService.save( vocabularyChangeDTO );
         }
-    }
-
-    private void checkEditCodeAuthorization( CodeSnippet codeSnippet, VersionDTO versionDTO, VocabularyDTO vocabularyDTO ) {
-        if ( codeSnippet.getActionType().equals( ActionType.EDIT_CODE ) )
-            SecurityUtils.checkResourceAuthorization( ActionType.EDIT_CODE,
-                vocabularyDTO.getAgencyId(), versionDTO.getLanguage() );
-        else if ( codeSnippet.getActionType().equals( ActionType.ADD_TL_CODE ) )
-            SecurityUtils.checkResourceAuthorization( ActionType.ADD_TL_CODE,
-                vocabularyDTO.getAgencyId(), versionDTO.getLanguage() );
-        else if ( codeSnippet.getActionType().equals( ActionType.EDIT_TL_CODE ) )
-            SecurityUtils.checkResourceAuthorization( ActionType.EDIT_TL_CODE,
-                vocabularyDTO.getAgencyId(), versionDTO.getLanguage() );
-        else if ( codeSnippet.getActionType().equals( ActionType.DELETE_TL_CODE ) )
-            SecurityUtils.checkResourceAuthorization( ActionType.DELETE_TL_CODE,
-                vocabularyDTO.getAgencyId(), versionDTO.getLanguage() );
     }
 
     private Integer getConceptPositionById( Long conceptId, Set<ConceptDTO> concepts ) {

--- a/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
@@ -1734,12 +1734,13 @@ public class VocabularyServiceImpl implements VocabularyService
 
     @Override
     @Transactional
-    public VersionDTO forwardStatus( VocabularySnippet vocabularySnippet ) {
+    public VersionDTO forwardStatus( VocabularySnippet vocabularySnippet ) throws IllegalActionTypeException
+    {
         if ( vocabularySnippet.getVersionId() == null ) {
-            throw new IllegalArgumentException( "Missing version id" );
+            throw new MissingIdentifierException( "Missing version id" );
         }
         if ( vocabularySnippet.getActionType() == null ) {
-            throw new IllegalArgumentException( "Missing action type" );
+            throw new IllegalActionTypeException();
         }
         VocabularyDTO vocabularyDTO = findOne( vocabularySnippet.getVocabularyId() )
             .orElseThrow( () -> new EntityNotFoundException( UNABLE_TO_FIND_VOCABULARY + vocabularySnippet.getVocabularyId() ) );
@@ -1879,7 +1880,7 @@ public class VocabularyServiceImpl implements VocabularyService
                 vocabularyDTO.setTitleDefinition(versionDTO.getTitle(), versionDTO.getDefinition(), versionDTO.getLanguage(), false);
                 break;
             default:
-                throw new IllegalArgumentException( "Action type not supported" + vocabularySnippet.getActionType() );
+                throw new IllegalActionTypeException( vocabularySnippet.getActionType() );
         }
         // check if SL published and not initial version, is there any TL needs to be cloned as
         // DRAFT?

--- a/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
@@ -463,12 +463,9 @@ public class EditorResource {
             .orElseThrow(() -> new EntityNotFoundException("Unable to add Vocabulary " + vocabularyId));
 
         // check for authorization
-        if (codeSnippets[0].getActionType().equals( ActionType.CREATE_CODE))
-            SecurityUtils.checkResourceAuthorization(ActionType.CREATE_CODE,
-                vocabularyDTO.getAgencyId(), versionDTO.getLanguage());
-        else if (codeSnippets[0].getActionType().equals( ActionType.ADD_TL_CODE))
-            SecurityUtils.checkResourceAuthorization(ActionType.ADD_TL_CODE,
-                vocabularyDTO.getAgencyId(), versionDTO.getLanguage());
+        for ( var snippet : codeSnippets ) {
+            SecurityUtils.checkResourceAuthorization( snippet.getActionType(), vocabularyDTO.getAgencyId(), versionDTO.getLanguage());
+        }
 
         List<ConceptDTO> storedCodes = new ArrayList<>();
         for (CodeSnippet codeSnippet : codeSnippets) {
@@ -476,34 +473,38 @@ public class EditorResource {
 
             ConceptDTO conceptDTO = null;
 
-            if (codeSnippet.getActionType().equals(ActionType.CREATE_CODE)) {
-                conceptDTO = addNewConcept(versionDTO, codeSnippet);
-            } else if (codeSnippet.getActionType().equals(ActionType.ADD_TL_CODE)) {
-                conceptDTO = versionDTO.getConcepts().stream().filter(c -> c.getId().equals(codeSnippet.getConceptId())).findFirst().orElse(null);
-                if (conceptDTO != null) {
-                    conceptDTO.setTitle(codeSnippet.getTitle());
-                    conceptDTO.setDefinition(codeSnippet.getDefinition());
+            switch ( codeSnippet.getActionType() )
+            {
+                case CREATE_CODE:
+                    conceptDTO = addNewConcept( versionDTO, codeSnippet );
+                    break;
+                case ADD_TL_CODE:
+                    conceptDTO = versionDTO.getConcepts().stream().filter( c -> c.getId().equals( codeSnippet.getConceptId() ) ).findFirst().orElse( null );
+                    if ( conceptDTO != null )
+                    {
+                        conceptDTO.setTitle( codeSnippet.getTitle() );
+                        conceptDTO.setDefinition( codeSnippet.getDefinition() );
 
-                    //notify the auditing mechanism
-                    String auditUserString = "";
-                    Optional<String> auditUser = SecurityUtils.getCurrentUserLogin();
-                    if (auditUser.isPresent()) {
-                        auditUserString = auditUser.get();
+                        //notify the auditing mechanism
+                        String auditUserString = SecurityUtils.getCurrentUserLogin().orElse( "" );
+                        auditPublisher.publish( auditUserString, vocabularyDTO, versionDTO, conceptDTO, null, codeSnippet, codeSnippet.getActionType().toString() );
                     }
-                    auditPublisher.publish(auditUserString, vocabularyDTO, versionDTO, conceptDTO, null, codeSnippet, "ADD_TL_CODE");
-                }
+                    break;
+                default:
+                    break;
             }
-            if (conceptDTO == null)
-                continue;
 
-            versionDTO = versionService.save(versionDTO);
+            if ( conceptDTO != null )
+            {
+                versionDTO = versionService.save( versionDTO );
 
-            // check if codeSnippet contains changeType, store if exist
-            vocabularyService.storeChangeType(codeSnippet, versionDTO);
+                // check if codeSnippet contains changeType, store if exist
+                vocabularyService.storeChangeType( codeSnippet, versionDTO );
 
-            // find the newly created code from version
-            ConceptDTO concept = versionDTO.findConceptByNotation(conceptDTO.getNotation());
-            storedCodes.add(concept);
+                // find the newly created code from version
+                ConceptDTO concept = versionDTO.findConceptByNotation( conceptDTO.getNotation() );
+                storedCodes.add( concept );
+            }
         }
 
         // index editor
@@ -511,7 +512,7 @@ public class EditorResource {
 
         String conceptsNotation = storedCodes.stream().map(ConceptDTO::getNotation).collect(Collectors.joining());
         if (conceptsNotation.length() > 20) {
-            conceptsNotation = conceptsNotation.substring(0, 20) + "...";
+            conceptsNotation = conceptsNotation.substring(0, 20).trim() + "...";
         }
         conceptsNotation += " (" + storedCodes.size() + " new codes added)";
 
@@ -522,8 +523,7 @@ public class EditorResource {
 
     private ConceptDTO addNewConcept(VersionDTO versionDTO, CodeSnippet codeSnippet) {
         // check if concept already exist for new concept
-        if (versionDTO.getConcepts().stream()
-            .anyMatch(c -> c.getNotation().equals(codeSnippet.getNotation()))) {
+        if (versionDTO.getConcepts().stream().anyMatch(c -> c.getNotation().equals(codeSnippet.getNotation()))) {
             throw new CodeAlreadyExistException(codeSnippet.getNotation());
         }
         // set position if not available
@@ -534,7 +534,7 @@ public class EditorResource {
 
         //notify the auditing mechanism
         String auditUserString = SecurityUtils.getCurrentUserLogin().orElse( "" );
-        auditPublisher.publish(auditUserString, null, versionDTO, newConceptDTO, null, codeSnippet, "CREATE_CODE");
+        auditPublisher.publish(auditUserString, null, versionDTO, newConceptDTO, null, codeSnippet, codeSnippet.getActionType().toString());
 
         // add concept to version and save version to save new concept
         versionDTO.addConceptAt(newConceptDTO, newConceptDTO.getPosition());
@@ -555,11 +555,18 @@ public class EditorResource {
     @PutMapping("/editors/codes")
     public ResponseEntity<ConceptDTO> updateCode(@Valid @RequestBody CodeSnippet codeSnippet) {
         log.debug("REST request to update Code/Concept : {}", codeSnippet);
-        if (!(codeSnippet.getActionType().equals(ActionType.EDIT_CODE) ||
-            codeSnippet.getActionType().equals(ActionType.ADD_TL_CODE) ||
-            codeSnippet.getActionType().equals(ActionType.EDIT_TL_CODE) ||
-            codeSnippet.getActionType().equals(ActionType.DELETE_TL_CODE)))
-            throw new IllegalArgumentException("Action type " + codeSnippet.getActionType() + "not supported");
+
+        switch ( codeSnippet.getActionType() )
+        {
+            case EDIT_CODE:
+            case ADD_TL_CODE:
+            case EDIT_TL_CODE:
+            case DELETE_TL_CODE:
+                break;
+            default:
+                throw new IllegalArgumentException( "Action type " + codeSnippet.getActionType() + "not supported" );
+        }
+
         if (codeSnippet.getConceptId() == null) {
             throw new BadRequestAlertException(INVALID_ID, ENTITY_CODE_NAME, ID_NULL);
         }

--- a/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
@@ -43,6 +43,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.FastByteArrayOutputStream;
@@ -130,20 +131,26 @@ public class EditorResource {
      * @throws InsufficientVocabularyAuthorityException {@code 403 (Forbidden)} if the user does not have sufficient rights to access the resource.
      */
     @PostMapping("/editors/vocabularies")
-    public ResponseEntity<VocabularyDTO> createVocabulary(@Valid @RequestBody VocabularySnippet vocabularySnippet) throws URISyntaxException {
+    public ResponseEntity<VocabularyDTO> createVocabulary(@Valid @RequestBody VocabularySnippet vocabularySnippet) throws URISyntaxException, IllegalActionTypeException
+    {
         log.debug("REST request to save Vocabulary : {}", vocabularySnippet);
         // check if user authorized to add VocabularyResource
-        if (vocabularySnippet.getActionType().equals( ActionType.CREATE_CV)) {
-            SecurityUtils.checkResourceAuthorization(ActionType.CREATE_CV, vocabularySnippet.getAgencyId(), vocabularySnippet.getLanguage());
+        if ( ActionType.CREATE_CV.equals( vocabularySnippet.getActionType() ) )
+        {
+            SecurityUtils.checkResourceAuthorization( ActionType.CREATE_CV, vocabularySnippet.getAgencyId(), vocabularySnippet.getLanguage() );
 
-            if (vocabularySnippet.getVocabularyId() != null) {
-                throw new BadRequestAlertException("A new vocabulary cannot already have an ID", ENTITY_VOCABULARY_NAME, ID_EXIST);
+            if ( vocabularySnippet.getVocabularyId() != null )
+            {
+                throw new BadRequestAlertException( "A new vocabulary cannot already have an ID", ENTITY_VOCABULARY_NAME, ID_EXIST );
             }
         }
-        else if (vocabularySnippet.getActionType().equals(ActionType.ADD_TL_CV)) {
-            SecurityUtils.checkResourceAuthorization(ActionType.ADD_TL_CV, vocabularySnippet.getAgencyId(), vocabularySnippet.getLanguage());
-        } else {
-            throw new IllegalArgumentException( "Illegal action type for POST" + vocabularySnippet.getActionType() );
+        else if ( ActionType.ADD_TL_CV.equals( vocabularySnippet.getActionType() ) )
+        {
+            SecurityUtils.checkResourceAuthorization( ActionType.ADD_TL_CV, vocabularySnippet.getAgencyId(), vocabularySnippet.getLanguage() );
+        }
+        else
+        {
+            throw new IllegalActionTypeException( vocabularySnippet.getActionType(), HttpMethod.POST );
         }
 
         VocabularyDTO result = vocabularyService.saveVocabulary(vocabularySnippet);
@@ -238,7 +245,8 @@ public class EditorResource {
      * @throws InsufficientVocabularyAuthorityException {@code 403 (Forbidden)} if the user does not have sufficient rights to access the resource.
      */
     @PutMapping("/editors/vocabularies/forward-status")
-    public ResponseEntity<VersionDTO> forwardStatusVocabulary(@Valid @RequestBody VocabularySnippet vocabularySnippet) {
+    public ResponseEntity<VersionDTO> forwardStatusVocabulary(@Valid @RequestBody VocabularySnippet vocabularySnippet) throws IllegalActionTypeException
+    {
         log.debug("REST request to update forward status Vocabulary : {}", vocabularySnippet);
         VersionDTO versionDTO = vocabularyService.forwardStatus(vocabularySnippet);
 

--- a/src/main/java/eu/cessda/cvs/web/rest/UserJWTController.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/UserJWTController.java
@@ -66,21 +66,17 @@ public class UserJWTController {
     /**
      * Object to return as body in JWT Authentication.
      */
-    static class JWTToken {
+    public static class JWTToken {
 
-        private String idToken;
+        private final String idToken;
 
-        JWTToken(String idToken) {
+        public JWTToken(String idToken) {
             this.idToken = idToken;
         }
 
         @JsonProperty("id_token")
-        String getIdToken() {
+        public String getIdToken() {
             return idToken;
-        }
-
-        void setIdToken(String idToken) {
-            this.idToken = idToken;
         }
     }
 }

--- a/src/main/java/eu/cessda/cvs/web/rest/errors/ExceptionTranslator.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/errors/ExceptionTranslator.java
@@ -17,8 +17,11 @@ package eu.cessda.cvs.web.rest.errors;
 
 import eu.cessda.cvs.service.ResourceNotFoundException;
 import io.github.jhipster.web.util.HeaderUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -35,6 +38,7 @@ import org.zalando.problem.violations.ConstraintViolationProblem;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,7 +49,9 @@ import java.util.stream.Collectors;
  * The error response follows <a href="https://tools.ietf.org/html/rfc7807">RFC7807 - Problem Details for HTTP APIs</a>.
  */
 @ControllerAdvice
+@ParametersAreNonnullByDefault
 public class ExceptionTranslator implements ProblemHandling, SecurityAdviceTrait {
+    private static final Logger log = LoggerFactory.getLogger( ExceptionTranslator.class );
 
     private static final String FIELD_ERRORS_KEY = "fieldErrors";
     private static final String MESSAGE_KEY = "message";
@@ -54,6 +60,22 @@ public class ExceptionTranslator implements ProblemHandling, SecurityAdviceTrait
 
     @Value("${jhipster.clientApp.name}")
     private String applicationName;
+
+    @Override
+    public void log( Throwable throwable, Problem problem, NativeWebRequest request, HttpStatus status )
+    {
+        switch ( status.series() ) {
+            case SERVER_ERROR:
+                log.error(status.getReasonPhrase(), throwable);
+                break;
+            case CLIENT_ERROR:
+                log.debug(status.getReasonPhrase(), throwable);
+                break;
+            default:
+                log.trace(status.getReasonPhrase(), throwable);
+                break;
+        }
+    }
 
     /**
      * Post-process the Problem payload to add the message key for the front-end if needed.
@@ -158,7 +180,7 @@ public class ExceptionTranslator implements ProblemHandling, SecurityAdviceTrait
     }
 
     @ExceptionHandler
-    public ResponseEntity<Problem> handleReseourceNotFound(ResourceNotFoundException ex, NativeWebRequest request) {
+    public ResponseEntity<Problem> handleResourceNotFound( ResourceNotFoundException ex, NativeWebRequest request) {
         return create(ex, request, HeaderUtil.createFailureAlert(applicationName, true, ex.getEntityName(), ex.getErrorKey(), ex.getMessage()));
     }
 }

--- a/src/main/java/eu/cessda/cvs/web/rest/errors/ExceptionTranslator.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/errors/ExceptionTranslator.java
@@ -69,7 +69,7 @@ public class ExceptionTranslator implements ProblemHandling, SecurityAdviceTrait
                 log.error(status.getReasonPhrase(), throwable);
                 break;
             case CLIENT_ERROR:
-                log.debug(status.getReasonPhrase(), throwable);
+                log.info(status.getReasonPhrase(), throwable);
                 break;
             default:
                 log.trace(status.getReasonPhrase(), throwable);

--- a/src/test/java/eu/cessda/cvs/web/rest/AccountResourceIT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/AccountResourceIT.java
@@ -128,7 +128,7 @@ class AccountResourceIT {
     void testGetUnknownAccount() throws Exception {
         restAccountMockMvc.perform(get("/api/account")
             .accept(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(status().isInternalServerError());
+            .andExpect(status().isNotFound());
     }
 
     @Test
@@ -417,7 +417,7 @@ class AccountResourceIT {
     @Transactional
     void testActivateAccountWithWrongKey() throws Exception {
         restAccountMockMvc.perform(get("/api/activate?key=wrongActivationKey"))
-            .andExpect(status().isInternalServerError());
+            .andExpect(status().isNotFound());
     }
 
     @Test
@@ -772,6 +772,6 @@ class AccountResourceIT {
             post("/api/account/reset-password/finish")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtil.convertObjectToJsonBytes(keyAndPassword)))
-            .andExpect(status().isInternalServerError());
+            .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/eu/cessda/cvs/web/rest/EditorResourceIT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/EditorResourceIT.java
@@ -1168,7 +1168,7 @@ class EditorResourceIT {
             .header("Authorization", jwt)
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtil.convertObjectToJsonBytes(vocabularySnippetForEnSl)))
-            .andExpect(status().is5xxServerError());
+            .andExpect(status().isBadRequest());
     }
 
     private void forwardSlStatusReviewTest(Version slVersion) throws Exception {
@@ -1337,7 +1337,7 @@ class EditorResourceIT {
             .header("Authorization", jwt)
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtil.convertObjectToJsonBytes(vocabularySnippetForEnSl)))
-            .andExpect(status().is5xxServerError());
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -1349,7 +1349,7 @@ class EditorResourceIT {
             .header("Authorization", jwt)
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtil.convertObjectToJsonBytes(vocabularySnippetForEnSl)))
-            .andExpect(status().is5xxServerError());
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -1360,7 +1360,7 @@ class EditorResourceIT {
             .header("Authorization", jwt)
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtil.convertObjectToJsonBytes(vocabularySnippetForEnSl)))
-            .andExpect(status().is5xxServerError());
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -1395,7 +1395,7 @@ class EditorResourceIT {
             .header("Authorization", jwt)
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtil.convertObjectToJsonBytes(vocabularySnippetForEnSl)))
-            .andExpect(status().is5xxServerError());
+            .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/eu/cessda/cvs/web/rest/VocabularyResourceV2IT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/VocabularyResourceV2IT.java
@@ -25,12 +25,12 @@ import eu.cessda.cvs.security.ActionType;
 import eu.cessda.cvs.security.AuthoritiesConstants;
 import eu.cessda.cvs.security.jwt.TokenProvider;
 import eu.cessda.cvs.service.ExportService;
+import eu.cessda.cvs.service.IllegalActionTypeException;
 import eu.cessda.cvs.service.VersionService;
 import eu.cessda.cvs.service.VocabularyService;
 import eu.cessda.cvs.service.dto.VersionDTO;
 import eu.cessda.cvs.service.dto.VocabularyDTO;
 import eu.cessda.cvs.web.rest.utils.ResourceUtils;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,11 +51,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -105,7 +104,8 @@ class VocabularyResourceV2IT {
     private VocabularyDTO vocabularyDTO;
 
     @BeforeEach
-    public void initTest() {
+    public void initTest() throws IllegalActionTypeException
+    {
         if( agency == null ) {
             agency = EditorResourceIT.createAgencyEntity();
             agency = agencyRepository.saveAndFlush(agency);

--- a/src/test/java/eu/cessda/cvs/web/rest/errors/ExceptionTranslatorTestController.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/errors/ExceptionTranslatorTestController.java
@@ -62,7 +62,7 @@ public class ExceptionTranslatorTestController {
 
     @GetMapping("/internal-server-error")
     public void internalServerError() {
-        throw new RuntimeException();
+        throw new RuntimeException("internal server error");
     }
 
     public static class TestDTO {


### PR DESCRIPTION
HTTP 500 status codes should only be returned when a unhandled exception occurs in the server, and should not be returned for expected error cases such as invalid parameters or resources not being found.

This PR adds `IllegalActionTypeException` which is thrown when an `ActionType` is passed to a method that cannot use it. `AccountResourceException` has been modified to return HTTP 400 to clients.

This PR quietens the logs by pushing client errors to be logged using the `debug` logging level.