### PR TITLE
Fix XSS warnings raised by CodeQL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
         }
         stage('Build and Push Docker Image') {
             steps {
-                sh 'gcloud auth configure-docker'
+                sh "gcloud auth configure-docker ${ARTIFACT_REGISTRY_HOST}"
                 withMaven {
                     sh "./mvnw jib:build -Pci -Djib.to.image=${IMAGE_TAG}"
                 }

--- a/src/main/java/eu/cessda/cvs/web/rest/UrnResolver.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/UrnResolver.java
@@ -61,11 +61,15 @@ public class UrnResolver {
         String baseUrl = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath();
 
         if( Character.isDigit( urn.charAt( urn.length() - 1) ))
+        {
             headers = getVersionByUrn(baseUrl, urn, lang);
+        }
         else
+        {
             headers = getVersionByUrnStartWith(baseUrl, urn);
-        if (headers.isPresent()) return headers.get();
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body( "URN: " + urn + " is not found" );
+        }
+
+        return headers.orElseGet( () -> ResponseEntity.notFound().build() );
     }
 
     private Optional<ResponseEntity<String>> getVersionByUrnStartWith(String baseUrl, String urn) {


### PR DESCRIPTION
The UrnResolver.findUrnResolver() method no longer returns the given URN if a resolver can't be found.