### PR TITLE
Refactor static file path to configure the directory to serve static resources from, fix most warnings logged by html2pdf, fix licence images not being converted correctly

### DIFF
--- a/src/main/java/eu/cessda/cvs/config/ApplicationProperties.java
+++ b/src/main/java/eu/cessda/cvs/config/ApplicationProperties.java
@@ -15,7 +15,14 @@
  */
 package eu.cessda.cvs.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Properties specific to Cvs.
@@ -25,49 +32,41 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "application", ignoreUnknownFields = false)
 public class ApplicationProperties {
-    private String vocabJsonPath;
-    private String staticFilePath;
-    private String uploadFilePath;
-    private String agencyImagePath;
-    private String licenseImagePath;
+    private static final Logger log = LoggerFactory.getLogger( ApplicationProperties.class );
 
-    public String getVocabJsonPath() {
-        return vocabJsonPath;
-    }
+    public final Path staticFilePath;
 
-    public void setVocabJsonPath(String vocabJsonPath) {
-        this.vocabJsonPath = vocabJsonPath;
-    }
-
-    public String getStaticFilePath() {
-        return staticFilePath;
-    }
-
-    public void setStaticFilePath(String staticFilePath) {
+    public ApplicationProperties(Path staticFilePath) throws IOException {
         this.staticFilePath = staticFilePath;
     }
 
-    public String getAgencyImagePath() {
-        return agencyImagePath;
+    @ConstructorBinding
+    public ApplicationProperties(String staticFilePath) throws IOException {
+        if (staticFilePath == null) {
+            this.staticFilePath = Files.createTempDirectory("cvs-static");
+            log.warn( "Static file directory not configured. Using temporary directory \"{}\"", this.staticFilePath );
+        } else {
+            this.staticFilePath = Path.of( staticFilePath );
+        }
     }
 
-    public void setAgencyImagePath(String agencyImagePath) {
-        this.agencyImagePath = agencyImagePath;
+    public Path getStaticFilePath() {
+        return staticFilePath;
     }
 
-    public String getLicenseImagePath() {
-        return licenseImagePath;
+    public Path getVocabJsonPath() {
+        return staticFilePath.resolve( "vocabularies" );
     }
 
-    public void setLicenseImagePath(String licenseImagePath) {
-        this.licenseImagePath = licenseImagePath;
+    public Path getAgencyImagePath() {
+        return staticFilePath.resolve( "images/agency" );
     }
 
-    public String getUploadFilePath() {
-        return uploadFilePath;
+    public Path getLicenseImagePath() {
+        return staticFilePath.resolve( "images/license" );
     }
 
-    public void setUploadFilePath(String uploadFilePath) {
-        this.uploadFilePath = uploadFilePath;
+    public Path getUploadFilePath() {
+        return staticFilePath.resolve( "file" );
     }
 }

--- a/src/main/java/eu/cessda/cvs/config/ApplicationProperties.java
+++ b/src/main/java/eu/cessda/cvs/config/ApplicationProperties.java
@@ -59,11 +59,11 @@ public class ApplicationProperties {
     }
 
     public Path getAgencyImagePath() {
-        return staticFilePath.resolve( "images/agency" );
+        return staticFilePath.resolve( "images" ).resolve( "agency" );
     }
 
     public Path getLicenseImagePath() {
-        return staticFilePath.resolve( "images/license" );
+        return staticFilePath.resolve( "images" ).resolve( "license" );
     }
 
     public Path getUploadFilePath() {

--- a/src/main/java/eu/cessda/cvs/config/SecurityConfiguration.java
+++ b/src/main/java/eu/cessda/cvs/config/SecurityConfiguration.java
@@ -66,6 +66,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/test/**");
     }
 
+    @SuppressWarnings( "ProhibitedExceptionDeclared" )
     @Override
     public void configure(HttpSecurity http) throws Exception {
         // @formatter:off
@@ -78,7 +79,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .accessDeniedHandler(problemSupport)
         .and()
             .headers()
-            .contentSecurityPolicy("default-src 'self' https://cdn.matomo.cloud https://cessda.matomo.cloud https://analytics.cessda.eu http://cdn.matomo.cloud/cessda.matomo.cloud/matomo https://eosc-helpdesk.eosc-portal.eu/api/v1/form_config https://eosc-helpdesk.eosc-portal.eu/api/v1/form_submit; frame-src 'self' https://cdn.matomo.cloud https://cessda.matomo.cloud https://cessda.atlassian.net http://cdn.matomo.cloud/cessda.matomo.cloud data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://cessda.matomo.cloud https://cessda.atlassian.net https://analytics.cessda.eu https://storage.googleapis.com http://cdn.matomo.cloud/cessda.matomo.cloud/matomo.js https://code.jquery.com/jquery-3.6.0.min.js https://eosc-helpdesk.eosc-portal.eu/assets/form/form.js; style-src 'self' https://fonts.googleapis.com https://eosc-helpdesk.eosc-portal.eu/assets/form/form.css 'unsafe-inline'; img-src 'self' https://cdn.matomo.cloud https://cessda.matomo.cloud https://cessda.atlassian.net https://analytics.cessda.eu http://cdn.matomo.cloud/cessda.matomo.cloud data:; font-src 'self' https://fonts.gstatic.com data:")
+            .contentSecurityPolicy("default-src 'self' https://cdn.matomo.cloud https://cessda.matomo.cloud https://analytics.cessda.eu http://cdn.matomo.cloud/cessda.matomo.cloud/matomo https://helpdesk.cessda.eu/api/v1/form_config https://helpdesk.cessda.eu/api/v1/form_submit; frame-src 'self' https://cdn.matomo.cloud https://cessda.matomo.cloud https://cessda.atlassian.net http://cdn.matomo.cloud/cessda.matomo.cloud data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.matomo.cloud https://cessda.matomo.cloud https://cessda.atlassian.net https://analytics.cessda.eu https://storage.googleapis.com http://cdn.matomo.cloud/cessda.matomo.cloud/matomo.js https://code.jquery.com/jquery-3.6.0.min.js https://helpdesk.cessda.eu/assets/form/form.js; style-src 'self' https://fonts.googleapis.com https://helpdesk.cessda.eu/assets/form/form.css 'unsafe-inline'; img-src 'self' https://cdn.matomo.cloud https://cessda.matomo.cloud https://cessda.atlassian.net https://analytics.cessda.eu http://cdn.matomo.cloud/cessda.matomo.cloud data:; font-src 'self' https://fonts.gstatic.com data:")
         .and()
             .referrerPolicy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN)
         .and()

--- a/src/main/java/eu/cessda/cvs/service/ExportService.java
+++ b/src/main/java/eu/cessda/cvs/service/ExportService.java
@@ -48,14 +48,11 @@ import java.util.Map;
 @Service
 public class ExportService
 {
-
-    public static final String HTML = "html";
-
     public enum DownloadType
 	{
 		SKOS("rdf", MediaType.APPLICATION_XML),
         PDF("pdf", MediaType.APPLICATION_PDF),
-        HTML(ExportService.HTML, MediaType.TEXT_HTML),
+        HTML("html", MediaType.TEXT_HTML),
         WORD("docx", new MediaType("application", "vnd.openxmlformats-officedocument.wordprocessingml.document" ));
 
 		private final String type;
@@ -109,10 +106,10 @@ public class ExportService
             case PDF:
             case HTML:
             case WORD:
-                content = templateEngine.process( HTML + "/" + templateName + "_" + type, ctx );
+                content = templateEngine.process( DownloadType.HTML.type + "/" + templateName + "_" + type, ctx );
                 break;
             case SKOS:
-                content = templateEngine.process( "xml" + "/"  + templateName + "_" + type, ctx )
+                content = templateEngine.process( DownloadType.SKOS.type + "/"  + templateName + "_" + type, ctx )
                     .replaceAll( "(?m)^[ \t]*\r?\n", "" );
                 break;
             default:

--- a/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
@@ -78,7 +78,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.function.Function;
@@ -800,7 +799,7 @@ public class VocabularyServiceImpl implements VocabularyService
         vocabularyEditorSearchRepository.deleteById( id );
         vocabularyPublishSearchRepository.deleteById( id );
         // delete files if any
-        deleteCvJsonDirectoryAndContent( Path.of( applicationProperties.getVocabJsonPath(), notation ) );
+        deleteCvJsonDirectoryAndContent( applicationProperties.getVocabJsonPath().resolve( notation ) );
     }
 
     public void deleteCvJsonDirectoryAndContent( Path dirPath ) {
@@ -818,7 +817,7 @@ public class VocabularyServiceImpl implements VocabularyService
                 e.addSuppressed( ede );
             }
 
-            // directory wasn't empty or an IO error occured
+            // directory wasn't empty or an IO error occurred
             log.error( "Unable to delete directory", e );
         }
     }
@@ -1123,7 +1122,7 @@ public class VocabularyServiceImpl implements VocabularyService
     @Override
     public List<Path> getPublishedCvPaths() {
         try ( Stream<Path> paths = Files.find(
-            Paths.get( applicationProperties.getVocabJsonPath() ), 2, (p, a) -> a.isRegularFile()
+            applicationProperties.getVocabJsonPath(), 2, (p, a) -> a.isRegularFile()
         ) ) {
             return paths.collect( Collectors.toList() );
         } catch (IOException e) {
@@ -1512,7 +1511,7 @@ public class VocabularyServiceImpl implements VocabularyService
         output.append( "Performing Vocabulary Publish JSON files creation.\n" );
         // remove all static JSON files on vocabulary (delete entire and including vocabulary
         // directory)
-        deleteCvJsonDirectoryAndContent( Path.of( applicationProperties.getVocabJsonPath() ) );
+        deleteCvJsonDirectoryAndContent( applicationProperties.getVocabJsonPath() );
         output.append( "Clean up: All existing JSON files are deleted.\n" );
 
         List<VocabularyDTO> vocabularyDTOS = findAll();
@@ -2135,7 +2134,7 @@ public class VocabularyServiceImpl implements VocabularyService
 
     private void readAgencyLogo( VocabularyDTO vocabularyDTO, AgencyDTO agencyDTO )
     {
-        Path logoFile = Path.of(applicationProperties.getAgencyImagePath(), vocabularyDTO.getAgencyLogo());
+        Path logoFile = applicationProperties.getAgencyImagePath().resolve( vocabularyDTO.getAgencyLogo() );
         try
         {
             String base64Data = readFileToBase64( logoFile );
@@ -2150,7 +2149,7 @@ public class VocabularyServiceImpl implements VocabularyService
 
     private void readLicenseLogo( VersionDTO versionDTO )
     {
-        Path licenceLogo = Path.of(applicationProperties.getLicenseImagePath(), versionDTO.getLicenseLogo());
+        Path licenceLogo = applicationProperties.getLicenseImagePath().resolve( versionDTO.getLicenseLogo() );
         try
         {
             String base64Data = readFileToBase64( licenceLogo );

--- a/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
@@ -2120,7 +2120,10 @@ public class VocabularyServiceImpl implements VocabularyService
             {
                 readLicenseLogo( versionDTO );
             }
+        }
 
+        for (VersionDTO versionDTO : vocabularyDTO.getVersions())
+        {
             if (versionDTO.getCanonicalUri() != null)
             {
                 int index = versionDTO.getCanonicalUri().lastIndexOf(':');

--- a/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
@@ -56,7 +56,6 @@ import javax.validation.Valid;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -352,7 +351,7 @@ public class EditorResource {
 
                 if( versionDTO.getStatus().equals(Status.PUBLISHED.toString())) {
                     // remove published JSON file, re-create the JSON file and re-index for published vocabulary
-                    vocabularyService.deleteCvJsonDirectoryAndContent( Path.of( applicationProperties.getVocabJsonPath(), vocabularyDTO.getNotation() ));
+                    vocabularyService.deleteCvJsonDirectoryAndContent( applicationProperties.getVocabJsonPath().resolve( vocabularyDTO.getNotation() ));
                     vocabularyService.generateJsonVocabularyPublish(vocabularyDTO);
                     vocabularyService.indexPublished(vocabularyDTO);
                 }
@@ -394,7 +393,7 @@ public class EditorResource {
         vocabularyService.indexEditor( vocabularyDTO );
         if( isTlPublished ) {
             // remove published JSON file, re-create the JSON file and re-index for published vocabulary
-            vocabularyService.deleteCvJsonDirectoryAndContent( Path.of( applicationProperties.getVocabJsonPath(), vocabularyDTO.getNotation() ) );
+            vocabularyService.deleteCvJsonDirectoryAndContent( applicationProperties.getVocabJsonPath().resolve( vocabularyDTO.getNotation() ) );
             vocabularyService.generateJsonVocabularyPublish(vocabularyDTO);
             vocabularyService.indexPublished(vocabularyDTO );
         }
@@ -839,9 +838,6 @@ public class EditorResource {
      * {@code PUT  /editors/comments} : Updates an existing comment via editor Rest API.
      *
      * @param commentDTO the commentDTO to update.
-     *
-     * @return the {@link ResponseEntity} with status {@code 201 (Created)} and with body the new CommentDTO, or with status {@code 400 (Bad Request)} if the comment has already an ID.
-     *
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the updated commentDTO,
      * or with status {@code 400 (Bad Request)} if the commentDTO is not valid,
      * or with status {@code 500 (Internal Server Error)} if the commentDTO couldn't be updated.
@@ -972,9 +968,6 @@ public class EditorResource {
      * {@code PUT  /editors/metadatas} : Updates an existing metadataValueDTO via editor Rest API.
      *
      * @param metadataValueDTO the metadataValueDTO to update.
-     *
-     * @return the {@link ResponseEntity} with status {@code 201 (Created)} and with body the new MetadataValueDTO, or with status {@code 400 (Bad Request)} if the metadataValueDTO has already an ID.
-     *
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the updated metadataValueDTO,
      * or with status {@code 400 (Bad Request)} if the metadataValueDTO is not valid,
      * or with status {@code 500 (Internal Server Error)} if the metadataValueDTO couldn't be updated.

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -40,7 +40,7 @@ spring:
       indent-output: true
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
-    url: jdbc:mysql://localhost:3306/cvs?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
+    url: jdbc:mysql://localhost:3311/cvs?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
     username: root
     password:
     hikari:
@@ -128,8 +128,4 @@ jhipster:
 # ===================================================================
 
 application:
-  static-file-path: src/main/webapp
-  vocab-json-path: src/main/webapp/content/vocabularies/
-  agency-image-path: src/main/webapp/content/images/agency/
-  license-image-path: src/main/webapp/content/images/license/
-  upload-file-path: src/main/webapp/content/file/
+  static-file-path: target/static-resources

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -137,7 +137,3 @@ jhipster:
 
 application:
   static-file-path: /app/resources/static
-  vocab-json-path: /app/resources/static/content/vocabularies/
-  agency-image-path: /app/resources/static/content/images/agency/
-  license-image-path: /app/resources/static/content/images/license/
-  upload-file-path: /app/resources/static/content/file/

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -164,7 +164,4 @@ jhipster:
 # ===================================================================
 
 application:
-  static-file-path: /app/resources/static
-  vocab-json-path: /app/resources/static/content/vocabularies/
-  agency-image-path: /app/resources/static/content/images/agency/
-  license-image-path: /app/resources/static/content/images/license/
+  static-file-path: # Unset by default

--- a/src/main/resources/templates/html/export_pdf.html
+++ b/src/main/resources/templates/html/export_pdf.html
@@ -30,8 +30,6 @@ hr {
   color: #D3D3D3; /*lightgrey */
   margin-top: 2em;
   margin-bottom: 2em;
-  margin-left: 10%;
-  margin-right: 10%;
 }
 table, th, td {
   border-style: solid;
@@ -48,7 +46,6 @@ thead {
   font-size: 120%;
 }
 th, td {
-  padding: 0.5em;
   vertical-align: top;
 }
 td.Code {
@@ -113,7 +110,7 @@ div.CodeList {
 
 		    <div class="page">
 		      <div style="width: 100%;">
-		      	<div style="width:130px;float:left;padding-right:15px">
+		      	<div th:if="${agency.logo != null}" style="width:130px;float:left;padding-right:15px">
 		      		<img alt="agency-logo" style="width:120px" th:src="@{${agency.logo}}"/>
 		    	</div>
 		    	<div>
@@ -174,9 +171,9 @@ div.CodeList {
 			        </thead>
 			        <tbody>
 			           <tr th:each="concept : ${version.concepts}" th:if="${!concept.deprecated}" >
-                        <td style="width: 25%;white-space:pre-line;word-break:break-all;word-wrap:break-word;" th:text="${concept.notation}"></td>
-			            <td style="width: 25%" th:text="${concept.title}"></td>
-			            <td style="width: 50%" th:text="${concept.definition}"></td>
+                        <td style="white-space:pre-line;word-break:break-all;" th:text="${concept.notation}"></td>
+                        <td style="word-break:break-word;" th:text="${concept.title}"></td>
+			            <td th:text="${concept.definition}"></td>
 			          </tr>
 			        </tbody>
 			      </table>
@@ -226,7 +223,7 @@ div.CodeList {
 		        <h2>License and citation</h2>
 			    <p>Copyright © <a th:href="${agency.link}" th:text="${agency.name}"></a> <span th:text="${year}"></span>.</p>
 			    <p th:if="${version.licenseName != null}">
-			    	<a rel="license" th:href="${version.licenseLink}">
+			    	<a th:if="${version.licenseLogo != null}" rel="license" th:href="${version.licenseLink}">
 			    	<img style="border-width:0;width:140px" alt="licanse-logo" th:attr="src=${version.licenseLogo},title=${version.licenseName},alt=${version.licenseName}" />
 			    	</a>
 					<span>This work is licensed under a

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -67,13 +67,13 @@
         <h1>You must enable javascript to view this page.</h1>
     </noscript>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
- 
+
   <button id="zammad-feedback-form" style="position: fixed; right: 0; bottom: 0;" >Send feedback</button>
-  <script id="zammad_form_script" src="https://eosc-helpdesk.eosc-portal.eu/assets/form/form.js"></script>
+  <script id="zammad_form_script" src="https://helpdesk.cessda.eu/assets/form/form.js"></script>
   <script>
     $(function() {
       $('#zammad-feedback-form').ZammadForm({
-    agreementMessage:'  Accept CESSDA <a target="_blank" href="https://www.cessda.eu/Privacy-policy">Data Privacy Policy</a> & <a target="_blank" href="https://www.cessda.eu/Acceptable-Use-Policy">Acceptable Use Policy</a>', 
+    agreementMessage:'  Accept CESSDA <a target="_blank" href="https://www.cessda.eu/Privacy-policy">Data Privacy Policy</a> & <a target="_blank" href="https://www.cessda.eu/Acceptable-Use-Policy">Acceptable Use Policy</a>',
     messageTitle: 'CVS Feedback Form',
     messageSubmit: 'Submit',
     messageThankYou: 'Thank you for your inquiry (#%s)! We\'ll contact you as soon as possible.',

--- a/src/test/java/eu/cessda/cvs/config/WebConfigurerTest.java
+++ b/src/test/java/eu/cessda/cvs/config/WebConfigurerTest.java
@@ -20,7 +20,6 @@ import io.github.jhipster.config.JHipsterProperties;
 import io.github.jhipster.web.filter.CachingHttpHeadersFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockServletContext;
@@ -31,12 +30,11 @@ import javax.servlet.Filter;
 import javax.servlet.FilterRegistration;
 import javax.servlet.Servlet;
 import javax.servlet.ServletRegistration;
-import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
@@ -57,7 +55,9 @@ public class WebConfigurerTest {
     private JHipsterProperties props;
 
     @BeforeEach
-    public void setup() {
+    public void setup() throws IOException {
+        ApplicationProperties app = new ApplicationProperties( "target/classes/static" );
+
         servletContext = spy(new MockServletContext());
         doReturn(mock(FilterRegistration.Dynamic.class))
             .when(servletContext).addFilter(anyString(), any(Filter.class));
@@ -67,7 +67,7 @@ public class WebConfigurerTest {
         env = new MockEnvironment();
         props = new JHipsterProperties();
 
-        webConfigurer = new WebConfigurer(env, props);
+        webConfigurer = new WebConfigurer(env, app, props);
     }
 
     @Test
@@ -84,16 +84,6 @@ public class WebConfigurerTest {
         webConfigurer.onStartup(servletContext);
 
         verify(servletContext, never()).addFilter(eq("cachingHttpHeadersFilter"), any(CachingHttpHeadersFilter.class));
-    }
-
-    @Test
-    public void testCustomizeServletContainer() {
-        env.setActiveProfiles(JHipsterConstants.SPRING_PROFILE_PRODUCTION);
-        TomcatServletWebServerFactory container = new TomcatServletWebServerFactory();
-        webConfigurer.customize(container);
-        if (container.getDocumentRoot() != null) {
-            assertThat(container.getDocumentRoot()).isEqualTo(new File("target/classes/static/"));
-        }
     }
 
     @Test

--- a/src/test/java/eu/cessda/cvs/service/MailServiceIT.java
+++ b/src/test/java/eu/cessda/cvs/service/MailServiceIT.java
@@ -100,8 +100,8 @@ public class MailServiceIT {
     private MailService mailService;
 
     @BeforeEach
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
+    public void setup() throws Exception {
+        MockitoAnnotations.openMocks(this).close();
         doNothing().when(javaMailSender).send(any(MimeMessage.class));
         mailService = new MailService(jHipsterProperties, javaMailSender, messageSource, templateEngine);
     }

--- a/src/test/java/eu/cessda/cvs/service/impl/VocabularyServiceImplTest.java
+++ b/src/test/java/eu/cessda/cvs/service/impl/VocabularyServiceImplTest.java
@@ -33,11 +33,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Random;
+import java.nio.file.Path;
+import java.util.*;
 
 import static java.lang.Math.abs;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -200,10 +201,11 @@ class VocabularyServiceImplTest
     }
 
     @Test
-    void shouldGetPublishedCVPaths() {
+    void shouldGetPublishedCVPaths() throws IOException, URISyntaxException
+    {
         // Setup
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setVocabJsonPath( "src/main/webapp/content/vocabularies" );
+        URL content = Objects.requireNonNull( this.getClass().getResource( "/static/content" ) );
+        ApplicationProperties applicationProperties = new ApplicationProperties( Path.of( content.toURI() ) );
         VocabularyServiceImpl vocabularyService = new VocabularyServiceImpl( null,
             null,
             null,

--- a/src/test/java/eu/cessda/cvs/web/rest/FileUploadResourceTestIT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/FileUploadResourceTestIT.java
@@ -16,9 +16,10 @@
 package eu.cessda.cvs.web.rest;
 
 import eu.cessda.cvs.CvsApp;
-import org.apache.commons.io.FileUtils;
+import eu.cessda.cvs.config.ApplicationProperties;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.file.PathUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -31,9 +32,9 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
 
@@ -51,6 +52,9 @@ class FileUploadResourceTestIT
 {
 
     @Autowired
+    private ApplicationProperties applicationProperties;
+
+    @Autowired
     private MockMvc fileUploadResourceMockMvc;
 
     @Test
@@ -63,7 +67,9 @@ class FileUploadResourceTestIT
             .andReturn();
 
         // Test if the newly created resource can be found at the location header
-        fileUploadResourceMockMvc.perform( get( result.getResponse().getHeader( "location" ) ) )
+        String location = result.getResponse().getHeader( "location" );
+        assertThat( location ).isNotNull();
+        fileUploadResourceMockMvc.perform( get( location ) )
             .andExpect( status().isOk() )
             .andExpect( content().contentType( MediaType.IMAGE_JPEG ) );
     }
@@ -78,7 +84,9 @@ class FileUploadResourceTestIT
             .andReturn();
 
         // Test if the newly created resource can be found at the location header
-        fileUploadResourceMockMvc.perform( get( result.getResponse().getHeader( "location" ) ) )
+        String location = result.getResponse().getHeader( "location" );
+        assertThat( location ).isNotNull();
+        fileUploadResourceMockMvc.perform( get( location ) )
             .andExpect( status().isOk() )
             .andExpect( content().contentType( MediaType.IMAGE_JPEG ) );
     }
@@ -96,7 +104,9 @@ class FileUploadResourceTestIT
             .andReturn();
 
         // Test if the newly created resource can be found at the location header
-        fileUploadResourceMockMvc.perform( get( result.getResponse().getHeader( "location" ) ) )
+        String location = result.getResponse().getHeader( "location" );
+        assertThat( location ).isNotNull();
+        fileUploadResourceMockMvc.perform( get( location ) )
             .andExpect( status().isOk() )
             // Uploaded file should be bitwise identical to the source
             .andExpect( content().bytes( topicClassificationJson ) );
@@ -121,8 +131,8 @@ class FileUploadResourceTestIT
             .andExpect( header().string("location", containsString(fileName + ".html"))  );
 
         // Verify that the HTML has been generated
-        File htmlFile = new File( "target/classes/static/content/file/", fileName + ".html" );
-        assertThat( FileUtils.readFileToString( htmlFile, StandardCharsets.UTF_8) ).contains( "Test document" );
+        Path htmlFile = applicationProperties.getUploadFilePath().resolve( fileName + ".html" );
+        assertThat( PathUtils.readString( htmlFile, StandardCharsets.UTF_8 ) ).contains( "Test document" );
     }
 
     @Test

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -119,8 +119,4 @@ jhipster:
 # ===================================================================
 
 application:
-  static-file-path: target/classes/static
-  vocab-json-path: target/classes/static/content/vocabularies-test/
-  agency-image-path: target/classes/static/content/images/agency/
-  license-image-path: target/classes/static/content/images/license/
-  upload-file-path: target/classes/static/content/file/
+  static-file-path: target/test-static-resources


### PR DESCRIPTION
This PR will allow CVS to use an external directory to store uploaded resources. If an upload directory isn't configured, a temporary directory will be configured and a warning will be logged on server startup.

The properties "vocabJsonPath", "uploadFilePath", "agencyImagePath" and "licenseImagePath" can no longer be explicitly set and are now derived from "staticFilePath".

When exporting a PDF instances of "Element does not fit current area. KeepTogether property will be ignored." will still be emitted.