### PR TITLE
Store temporary instances of exported resources on the file system

### DIFF
--- a/src/main/java/eu/cessda/cvs/config/ApplicationProperties.java
+++ b/src/main/java/eu/cessda/cvs/config/ApplicationProperties.java
@@ -69,4 +69,8 @@ public class ApplicationProperties {
     public Path getUploadFilePath() {
         return staticFilePath.resolve( "file" );
     }
+
+    public Path getExportFilePath() {
+        return staticFilePath.resolve( "export" );
+    }
 }

--- a/src/main/java/eu/cessda/cvs/service/ExportService.java
+++ b/src/main/java/eu/cessda/cvs/service/ExportService.java
@@ -37,11 +37,11 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 
 import javax.xml.bind.JAXBException;
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,6 +51,8 @@ public class ExportService
 {
     public static final String MEDIATYPE_RDF_VALUE = "application/rdf+xml";
     public static final MediaType MEDIATYPE_RDF = MediaType.parseMediaType(MEDIATYPE_RDF_VALUE);
+    public static final String MEDIATYPE_WORD_VALUE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    public static final MediaType MEDIATYPE_WORD = MediaType.parseMediaType( MEDIATYPE_WORD_VALUE );
 
     private final FontSet fontSet;
 
@@ -59,7 +61,7 @@ public class ExportService
 		SKOS("rdf", MEDIATYPE_RDF),
         PDF("pdf", MediaType.APPLICATION_PDF),
         HTML("html", MediaType.TEXT_HTML),
-        WORD("docx", new MediaType("application", "vnd.openxmlformats-officedocument.wordprocessingml.document" ));
+        WORD("docx", MEDIATYPE_WORD );
 
 		private final String type;
         private final MediaType mediaType;
@@ -98,7 +100,7 @@ public class ExportService
 	private final SpringTemplateEngine templateEngine;
 
     @SuppressWarnings( "DataFlowIssue" )
-	public ExportService(SpringTemplateEngine templateEngine )
+	public ExportService( SpringTemplateEngine templateEngine )
 	{
         this.templateEngine = templateEngine;
         this.fontSet = new FontSet();
@@ -157,9 +159,9 @@ public class ExportService
 
 	private void createTextFile( String contents, OutputStream outputStream ) throws IOException
     {
-        BufferedWriter bw = new BufferedWriter( new OutputStreamWriter( outputStream ) );
-        bw.write( contents );
-        bw.flush();
+        OutputStreamWriter writer = new OutputStreamWriter( outputStream, StandardCharsets.UTF_8 );
+        writer.write( contents );
+        writer.flush();
 	}
 
     public void createPdfFile( String contents, OutputStream outputStream )

--- a/src/main/java/eu/cessda/cvs/service/VocabularyService.java
+++ b/src/main/java/eu/cessda/cvs/service/VocabularyService.java
@@ -25,7 +25,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -230,18 +229,15 @@ public interface VocabularyService {
      * @param downloadType one of the following file types PDF, DOCX, HTML, RDF
      * @param requestURL request URL for statistical purposes
      * @param onlyPublished only select published vocabularies
-     * @param outputStream stream for the result to be written to.
-     * @return the generated file name
+     * @return the generated file's resolved path
      */
-    String generateVocabularyFileDownload(
+    Path generateVocabularyFileDownload(
         String vocabularyNotation,
         String versionSl,
         String versionList,
         ExportService.DownloadType downloadType,
         String requestURL,
-        boolean onlyPublished,
-        OutputStream outputStream);
-
+        boolean onlyPublished);
 
     /**
      *

--- a/src/main/java/eu/cessda/cvs/service/VocabularyService.java
+++ b/src/main/java/eu/cessda/cvs/service/VocabularyService.java
@@ -229,33 +229,19 @@ public interface VocabularyService {
      * @param versionList combination of language and version number, e.g. en_1.0
      * @param downloadType one of the following file types PDF, DOCX, HTML, RDF
      * @param requestURL request URL for statistical purposes
+     * @param onlyPublished only select published vocabularies
+     * @param outputStream stream for the result to be written to.
      * @return the generated file name
      */
-    String generateVocabularyPublishFileDownload(
+    String generateVocabularyFileDownload(
         String vocabularyNotation,
         String versionSl,
         String versionList,
         ExportService.DownloadType downloadType,
         String requestURL,
+        boolean onlyPublished,
         OutputStream outputStream);
 
-    /**
-     * Generate files to be exported for specific vocabulary from the editor
-     *
-     * @param vocabularyNotation the vocabulary notation
-     * @param versionSl the Source Language version
-     * @param versionList combination of language anf version number, e.g. en_1.0
-     * @param downloadType one of the following file types PDF, DOCX, HTML, RDF
-     * @param requestURL request URL for statistical purposes
-     * @return the generated file name
-     */
-    String generateVocabularyEditorFileDownload(
-        String vocabularyNotation,
-        String versionSl,
-        String versionList,
-        ExportService.DownloadType downloadType,
-        String requestURL,
-        OutputStream outputStream);
 
     /**
      *

--- a/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
@@ -1694,30 +1694,100 @@ public class VocabularyServiceImpl implements VocabularyService
     }
 
     @Override
-    public String generateVocabularyPublishFileDownload(
-        String vocabularyNotation,
-        String versionSl,
-        String versionList,
-        ExportService.DownloadType downloadType,
-        String requestURL,
-        OutputStream outputStream) {
-        log.info( "Publication generate file {} for Vocabulary {} versionSl {}", downloadType, vocabularyNotation, versionSl );
-        VocabularyDTO vocabularyDTO = getVocabularyByNotationAndVersion( vocabularyNotation, versionSl, true );
-        return generateVocabularyFileDownload( vocabularyNotation, versionSl, versionList, downloadType, requestURL, vocabularyDTO, outputStream );
+    public String generateVocabularyFileDownload( String vocabularyNotation, String versionSl, String versionList, ExportService.DownloadType downloadType, String requestURL, boolean onlyPublished, OutputStream outputStream )
+    {
+        log.info( "Generate file {} for Vocabulary {} versionSl {}", downloadType, vocabularyNotation, versionSl );
+        VocabularyDTO vocabularyDTO = getVocabularyByNotationAndVersion( vocabularyNotation, versionSl, onlyPublished );
+
+        Set<VersionDTO> includedVersions = filterOutVocabularyVersions( versionList, vocabularyDTO );
+
+        // 604 - duplicate entries in SKOS output
+        if ( downloadType.equals( ExportService.DownloadType.SKOS ) ) {
+            Map<String, VersionDTO> latestVersionsMap = new LinkedHashMap<>();
+            for (VersionDTO versionDTO : includedVersions) {
+                latestVersionsMap.merge(versionDTO.getLanguage(), versionDTO,
+                    // Select the latest version (defined by the lower result from the comparator)
+                    (r, k) -> VocabularyUtils.VERSION_DTO_COMPARATOR.compare(r, k) < 0 ? r : k
+                );
+            }
+            includedVersions = new LinkedHashSet<>(latestVersionsMap.values());
+        }
+
+        vocabularyDTO.setVersions( includedVersions );
+        Map<String, Object> map = new HashMap<>();
+        for ( VersionDTO includedVersion : includedVersions ) {
+            // escaping HTML to strict XHTML
+            includedVersion.setVersionNotes( VocabularyUtils.toStrictXhtml( includedVersion.getVersionNotes() ) );
+            includedVersion.setVersionChanges( VocabularyUtils.toStrictXhtml( includedVersion.getVersionChanges() ) );
+            includedVersion.setDdiUsage( VocabularyUtils.toStrictXhtml( includedVersion.getDdiUsage() ) );
+            // sort concepts by position (see #330)
+            includedVersion.setConcepts(
+                includedVersion.getConcepts().stream().sorted( Comparator.comparing( ConceptDTO::getPosition ) )
+                    .collect( Collectors.toCollection( LinkedHashSet::new ) ) );
+        }
+
+        // sorted versions
+        map.put( "versions", includedVersions );
+
+        // agency object
+        AgencyDTO agencyDTO = new AgencyDTO();
+        agencyDTO.setName( vocabularyDTO.getAgencyName() );
+        agencyDTO.setLink( vocabularyDTO.getAgencyLink() );
+
+        if ( downloadType.equals( ExportService.DownloadType.SKOS ) ) {
+            final VersionDTO versionIncluded = includedVersions.iterator().next();
+            String uriSl = versionIncluded.getUriSl();
+            if ( uriSl == null ) {
+                uriSl = versionIncluded.getUri();
+            }
+            map.put( "docId", uriSl );
+            map.put( "docVersionOf", vocabularyDTO.getUri() );
+            map.put( "docNotation", vocabularyDTO.getNotation() );
+            map.put( "docSourceLanguage", vocabularyDTO.getSourceLanguage() );
+            map.put( "docVersion", versionIncluded.getNumber().toString() );
+            map.put( "docLicense", versionIncluded.getLicenseName() );
+            map.put( "docLicenseUrl", versionIncluded.getLicenseLink() );
+            map.put( "docRight", versionIncluded.getLicenseName() );
+            map.put( CODE_PATH, CodeDTO.generateCodesFromVersion( includedVersions, false ) );
+        } else {
+            vocabularyDTO.setVersions( includedVersions );
+            prepareAdditionalAttributesForNonSkos( vocabularyDTO, map, agencyDTO );
+        }
+
+        map.put( "agency", agencyDTO );
+
+        // Derive the year from the date of publication, falling back to the last modified date if present.
+        // Otherwise, the current date is used to provide the year.
+        int year;
+        if ( vocabularyDTO.getPublicationDate() != null) {
+            year = vocabularyDTO.getPublicationDate().getYear();
+        } else {
+            if ( vocabularyDTO.getLastModified() != null) {
+                year = vocabularyDTO.getLastModified().getYear();
+            } else {
+                year = LocalDate.now().getYear();
+            }
+        }
+        map.put( "year", year );
+        map.put( "baseUrl", requestURL );
+
+        String suffix = "";
+        if (agencyDTO.getName().equals("DDI Alliance") && downloadType.equals(ExportService.DownloadType.SKOS)) {
+            suffix = "-ddi";
+        }
+
+        try
+        {
+            // The output stream is set by the calling method
+            exportService.generateFileByThymeleafTemplate( "export" + suffix, map, downloadType, outputStream );
+            return vocabularyNotation + "-" + versionSl + "_" + versionList + "." + downloadType;
+        }
+        catch ( IOException | JAXBException | Docx4JException e )
+        {
+            throw new VocabularyFileGenerationFailedException( e );
+        }
     }
 
-    @Override
-    public String generateVocabularyEditorFileDownload(
-        String vocabularyNotation,
-        String versionSl,
-        String versionList,
-        ExportService.DownloadType downloadType,
-        String requestURL,
-        OutputStream outputStream) {
-        log.info( "Editor generate file {} for Vocabulary {} versionSl {}", downloadType, vocabularyNotation, versionSl );
-        VocabularyDTO vocabularyDTO = getVocabularyByNotationAndVersion( vocabularyNotation, versionSl, false );
-        return generateVocabularyFileDownload( vocabularyNotation, versionSl, versionList, downloadType, requestURL, vocabularyDTO, outputStream );
-    }
 
     @Override
     @Transactional
@@ -1980,104 +2050,6 @@ public class VocabularyServiceImpl implements VocabularyService
             for ( Concept concept : version.getConcepts() ) {
                 concept.setUri( null );
             }
-        }
-    }
-
-    private String generateVocabularyFileDownload(
-        String vocabularyNotation,
-        String versionSl,
-        String versionList,
-        ExportService.DownloadType downloadType,
-        String requestURL,
-        VocabularyDTO vocabularyDTO,
-        OutputStream outputStream) {
-
-        Set<VersionDTO> includedVersions = filterOutVocabularyVersions( versionList, vocabularyDTO);
-
-        // 604 - duplicate entries in SKOS output
-        if ( downloadType.equals( ExportService.DownloadType.SKOS ) ) {
-            Map<String, VersionDTO> latestVersionsMap = new LinkedHashMap<>();
-            for (VersionDTO versionDTO : includedVersions) {
-                latestVersionsMap.merge(versionDTO.getLanguage(), versionDTO,
-                    // Select the latest version (defined by the lower result from the comparator)
-                    (r, k) -> VocabularyUtils.VERSION_DTO_COMPARATOR.compare(r, k) < 0 ? r : k
-                );
-            }
-            includedVersions = new LinkedHashSet<>(latestVersionsMap.values());
-        }
-
-        vocabularyDTO.setVersions( includedVersions );
-        Map<String, Object> map = new HashMap<>();
-        for ( VersionDTO includedVersion : includedVersions ) {
-            // escaping HTML to strict XHTML
-            includedVersion.setVersionNotes( VocabularyUtils.toStrictXhtml( includedVersion.getVersionNotes() ) );
-            includedVersion.setVersionChanges( VocabularyUtils.toStrictXhtml( includedVersion.getVersionChanges() ) );
-            includedVersion.setDdiUsage( VocabularyUtils.toStrictXhtml( includedVersion.getDdiUsage() ) );
-            // sort concepts by position (see #330)
-            includedVersion.setConcepts(
-                includedVersion.getConcepts().stream().sorted( Comparator.comparing( ConceptDTO::getPosition ) )
-                    .collect( Collectors.toCollection( LinkedHashSet::new ) ) );
-        }
-
-        // sorted versions
-        map.put( "versions", includedVersions );
-
-        // agency object
-        AgencyDTO agencyDTO = new AgencyDTO();
-        agencyDTO.setName( vocabularyDTO.getAgencyName() );
-        agencyDTO.setLink( vocabularyDTO.getAgencyLink() );
-
-        if ( downloadType.equals( ExportService.DownloadType.SKOS ) ) {
-            final VersionDTO versionIncluded = includedVersions.iterator().next();
-            String uriSl = versionIncluded.getUriSl();
-            if ( uriSl == null ) {
-                uriSl = versionIncluded.getUri();
-            }
-            map.put( "docId", uriSl );
-            map.put( "docVersionOf", vocabularyDTO.getUri() );
-            map.put( "docNotation", vocabularyDTO.getNotation() );
-            map.put( "docSourceLanguage", vocabularyDTO.getSourceLanguage() );
-            map.put( "docVersion", versionIncluded.getNumber().toString() );
-            map.put( "docLicense", versionIncluded.getLicenseName() );
-            map.put( "docLicenseUrl", versionIncluded.getLicenseLink() );
-            map.put( "docRight", versionIncluded.getLicenseName() );
-            map.put( CODE_PATH, CodeDTO.generateCodesFromVersion( includedVersions, false ) );
-        } else {
-            vocabularyDTO.setVersions( includedVersions );
-            prepareAdditionalAttributesForNonSkos( vocabularyDTO, map, agencyDTO );
-        }
-
-        map.put( "agency", agencyDTO );
-
-        // Derive the year from the date of publication, falling back to the last modified date if present.
-        // Otherwise, the current date is used to provide the year.
-        int year;
-        if (vocabularyDTO.getPublicationDate() != null) {
-            year = vocabularyDTO.getPublicationDate().getYear();
-        } else {
-            if (vocabularyDTO.getLastModified() != null) {
-                year = vocabularyDTO.getLastModified().getYear();
-            } else {
-                year = LocalDate.now().getYear();
-            }
-        }
-        map.put( "year", year );
-        map.put( "baseUrl", requestURL );
-
-        String suffix = "";
-        if (agencyDTO.getName().equals("DDI Alliance") && downloadType.equals(ExportService.DownloadType.SKOS)) {
-            suffix = "-ddi";
-        }
-
-        try
-        {
-            // The output stream is set by the calling method
-            exportService.generateFileByThymeleafTemplate( "export" + suffix, map, downloadType, outputStream );
-            return vocabularyNotation + "-" + versionSl + "_" + versionList + "." + downloadType;
-        }
-        catch ( IOException | JAXBException | Docx4JException e )
-        {
-            throw new VocabularyFileGenerationFailedException( e );
         }
     }
 

--- a/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
@@ -1695,8 +1695,14 @@ public class VocabularyServiceImpl implements VocabularyService
     @Override
     public Path generateVocabularyFileDownload( String vocabularyNotation, String versionSl, String versionList, ExportService.DownloadType downloadType, String requestURL, boolean onlyPublished )
     {
-        var fileName = vocabularyNotation + "-" + versionSl + "_" + versionList + "." + downloadType;
-        var resolvedPath = applicationProperties.getExportFilePath().resolve( fileName );
+        var fileNameStringBuilder = new StringBuilder().append( vocabularyNotation ).append( "-" ).append( versionSl );
+        if (versionList != null)
+        {
+            // version list may be null, only append if non-null
+            fileNameStringBuilder.append( "_" ).append( versionList );
+        }
+        fileNameStringBuilder.append( "." ).append( downloadType );
+        var resolvedPath = applicationProperties.getExportFilePath().resolve( fileNameStringBuilder.toString() );
 
         // Test if a pre-existing export is present
         if (Files.isRegularFile( resolvedPath )) {

--- a/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
@@ -38,7 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -46,7 +46,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.FastByteArrayOutputStream;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -56,6 +55,7 @@ import javax.validation.Valid;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -1047,25 +1047,20 @@ public class EditorResource {
      * @param lv included version to be exported with format language_version e.g en-1.0_de-1.0.1
      */
     @GetMapping(path = "/editors/download/{cv}/{v}", produces = { ExportService.MEDIATYPE_RDF_VALUE, MediaType.APPLICATION_PDF_VALUE, MediaType.TEXT_HTML_VALUE })
-    public ResponseEntity<Resource> getVocabularyInPdf(
+    public ResponseEntity<Resource> getVocabularyDownload(
         HttpServletRequest request, @PathVariable String cv, @PathVariable String v,
         @RequestParam(name = "lv", required = true) String lv
     ) {
         log.debug("Editor REST request to get a PDF file of vocabulary {} with version {} with included versions {}", cv, v, lv);
 
-        var outputStream = new FastByteArrayOutputStream();
         var requestURL = ResourceUtils.getURLWithContextPath( request );
         var mediaType = MediaType.parseMediaType( request.getHeader( "accept" ) );
         var type = ExportService.DownloadType.fromMediaType( mediaType ).orElseThrow(); // produces attribute should restrict to acceptable values
-        String fileName = vocabularyService.generateVocabularyFileDownload( cv, v, lv, type , requestURL, false, outputStream );
-
-        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName);
+        Path fileName = vocabularyService.generateVocabularyFileDownload( cv, v, lv, type , requestURL, false );
         return ResponseEntity.ok()
-            .headers(headers)
+            .header(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName.getFileName())
             .contentType(type.getMediaType())
-            .body(resource);
+            .body(new FileSystemResource( fileName ) );
     }
 
     /**

--- a/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
@@ -35,7 +35,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -43,12 +43,12 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.FastByteArrayOutputStream;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -71,7 +71,7 @@ public class VocabularyResourceV2 {
 
     private final VocabularyService vocabularyService;
 
-    public VocabularyResourceV2(VocabularyService vocabularyService) {
+    public VocabularyResourceV2( VocabularyService vocabularyService ) {
         this.vocabularyService = vocabularyService;
     }
 
@@ -282,7 +282,7 @@ public class VocabularyResourceV2 {
         Set<String> langSet = new HashSet<>();
         langSet.add( lang );
 
-        List<Object> vocabularyJsonLds = new ArrayList<>();
+        List<Map<String, Object>> vocabularyJsonLds = new ArrayList<>();
         if ( !vocabulariesPage.getContent().isEmpty() ) {
             vocabulariesPage.getContent().forEach(vocabularyDTO -> {
                 List<Map<String, Object>> vocabularyJsonLdMap = ResourceUtils.convertVocabularyDtoToJsonLdSkosMos(vocabularyDTO, vocabularyDTO.getCodes(), langSet);
@@ -330,9 +330,9 @@ public class VocabularyResourceV2 {
         ) @RequestParam( required = false )  String languageVersion
     ) {
         log.debug("REST request to redirect of vocabulary {} with version {} with included versions {}", vocabulary, versionNumberSl, languageVersion);
-        HttpHeaders headers = new HttpHeaders();
-        headers.setLocation(URI.create( ResourceUtils.getBasePath(request) + "vocabulary/" + vocabulary + "?v=" + versionNumberSl));
-        return new ResponseEntity<>(headers, HttpStatus.TEMPORARY_REDIRECT);
+        return ResponseEntity.status(HttpStatus.TEMPORARY_REDIRECT)
+            .location( URI.create( request.getContextPath() + "/vocabulary/" + vocabulary + "?v=" + versionNumberSl) )
+            .build();
     }
 
     /**
@@ -518,11 +518,11 @@ public class VocabularyResourceV2 {
      * @param vocabulary
      * @param versionNumberSl
      * @param languageVersion
-     * @return Vocabulary in PDF format
+     * @return Vocabulary
      */
     @GetMapping(
         value="/vocabularies/{vocabulary}/{versionNumberSl}",
-        produces = MediaType.APPLICATION_PDF_VALUE
+        produces = { MediaType.APPLICATION_PDF_VALUE, ExportService.MEDIATYPE_WORD_VALUE, ExportService.MEDIATYPE_RDF_VALUE }
     )
     @ApiOperation( value = "Get a Vocabulary in PDF file" )
     public ResponseEntity<Resource> getVocabularyPdf(
@@ -549,91 +549,18 @@ public class VocabularyResourceV2 {
         ) @RequestParam( required = false )  String languageVersion
     ) {
         log.debug("REST request to get a PDF file of vocabulary {} with version {} with included versions {}", vocabulary, versionNumberSl, languageVersion);
-        return transformVocabularyToPdf(request, vocabulary, versionNumberSl, languageVersion);
-    }
 
-    /**
-     * {@code GET  /vocabularies/:vocabulary/:versionNumberSl} : Get Vocabulary
-     *
-     * @param request
-     * @param vocabulary
-     * @param versionNumberSl
-     * @param languageVersion
-     * @return Vocabulary in WORD-DOCX format
-     */
-    @GetMapping(
-        value="/vocabularies/{vocabulary}/{versionNumberSl}",
-        produces = DOCX_TYPE
-    )
-    @ApiOperation( value = "Get a Vocabulary in DOCX file" )
-    public ResponseEntity<Resource> getVocabularyDocx(
-        HttpServletRequest request,
-        @ApiParam(
-            name = "vocabulary",
-            type = "String",
-            value = "The vocabulary",
-            example = "TopicClassification",
-            required = true
-        ) @PathVariable String vocabulary,
-        @ApiParam(
-            name = "versionNumberSl",
-            type = "String",
-            value = "The version number of Source language",
-            example = "4.0",
-            required = true
-        ) @PathVariable String versionNumberSl,
-        @ApiParam(
-            name = "languageVersion",
-            type = "String",
-            value = "included language version, e.g. en-4.0_de-4.0.1, separated by _" ,
-            example = "en-4.0"
-        ) @RequestParam( required = false )  String languageVersion
-    ) {
-        log.debug("REST request to get a WORD-DOCX  file of vocabulary {} with version {} with included versions {}", vocabulary, versionNumberSl, languageVersion);
-        return transformVocabularyToDocx(request, vocabulary, versionNumberSl, languageVersion);
-    }
+        var requestURL = ResourceUtils.getURLWithContextPath( request );
+        var mediaType = MediaType.parseMediaType( request.getHeader( "accept" ) );
+        var type = ExportService.DownloadType.fromMediaType( mediaType ).orElseThrow(); // produces attribute should restrict to acceptable values
 
-    /**
-     * {@code GET  /vocabularies/:vocabulary/:versionNumberSl} : Get Vocabulary
-     *
-     * @param request
-     * @param vocabulary
-     * @param versionNumberSl
-     * @param languageVersion
-     * @return Vocabulary in Skos RDF file
-     */
-    @GetMapping(
-        value="/vocabularies/{vocabulary}/{versionNumberSl}",
-        produces = { ExportService.MEDIATYPE_RDF_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE }
-    )
-    @ApiOperation( value = "Get a Vocabulary in Skos RDF file" )
-    public ResponseEntity<Resource> getVocabularySkosRdf(
-        HttpServletRequest request,
-        @ApiParam(
-            name = "vocabulary",
-            type = "String",
-            value = "The vocabulary",
-            example = "TopicClassification",
-            required = true
-        ) @PathVariable String vocabulary,
-        @ApiParam(
-            name = "versionNumberSl",
-            type = "String",
-            value = "The version number of Source language",
-            example = "4.0",
-            required = true
-        ) @PathVariable String versionNumberSl,
-        @ApiParam(
-            name = "languageVersion",
-            type = "String",
-            value = "included language version, e.g. en-4.0_de-4.0.1, separated by _" ,
-            example = "en-4.0"
-        ) @RequestParam( required = false ) String languageVersion
-    ) {
-        log.debug("REST request to get a SKOS RDF file of vocabulary {} with version {} with included versions {}", vocabulary, versionNumberSl, languageVersion);
-        return transformVocabularyToRdf(request, vocabulary, versionNumberSl, languageVersion);
-    }
+        Path fileName = vocabularyService.generateVocabularyFileDownload( vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.PDF, requestURL, true );
 
+        return ResponseEntity.ok()
+            .contentType( type.getMediaType() )
+            .header(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName.getFileName())
+            .body(new FileSystemResource( fileName ) );
+    }
 
     /**
      * {@code GET  /vocabularies/html/:vocabulary/:versionNumberSl} : Get Vocabulary in
@@ -646,7 +573,7 @@ public class VocabularyResourceV2 {
      * @return Vocabulary in HTML format
      *
      */
-    @GetMapping("/vocabularies/html/{vocabulary}/{versionNumberSl}")
+    @GetMapping(value = "/vocabularies/html/{vocabulary}/{versionNumberSl}", produces = MediaType.TEXT_HTML_VALUE)
     @ApiOperation( value = "Get a Vocabulary in HTML format", hidden = true )
     public ResponseEntity<Resource> getVocabularyInHtml(
         HttpServletRequest request,
@@ -669,7 +596,7 @@ public class VocabularyResourceV2 {
      * @return Vocabulary in JSON format
      *
      */
-    @GetMapping("/vocabularies/json/{vocabulary}/{versionNumberSl}")
+    @GetMapping(value = "/vocabularies/json/{vocabulary}/{versionNumberSl}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation( value = "Get a Vocabulary in JSON format", hidden = true )
     public ResponseEntity<VocabularyDTO> getVocabularyInJson(
         HttpServletRequest request,
@@ -692,7 +619,7 @@ public class VocabularyResourceV2 {
      * @return Vocabulary in JSON-LD format
      *
      */
-    @GetMapping("/vocabularies/jsonld/{vocabulary}/{versionNumberSl}")
+    @GetMapping(value = "/vocabularies/jsonld/{vocabulary}/{versionNumberSl}", produces = JSONLD_TYPE)
     @ApiOperation( value = "Get a Vocabulary in JSON-LD format", hidden = true )
     public ResponseEntity<List<Object>> getVocabularyInJsonLd(
         HttpServletRequest request,
@@ -704,73 +631,6 @@ public class VocabularyResourceV2 {
         return transformVocabularyToJsonLd(vocabulary, versionNumberSl, languageVersion);
     }
 
-    /**
-     * {@code GET  /v2/vocabularies/pdf/:notation/:versionNumber}
-     *  get a PDF file of vocabulary {vocabulary} with version {versionNumberSl} with included versions {languageVersion}
-     * Hidden from Swagger due to API for CVS front-end
-     *
-     * @param vocabulary
-     * @param versionNumberSl
-     * @param languageVersion
-     * @return Vocabulary in PDF format
-     *
-     */
-    @GetMapping("/vocabularies/pdf/{vocabulary}/{versionNumberSl}")
-    @ApiOperation( value = "Get a Vocabulary in PDF format", hidden = true )
-    public ResponseEntity<Resource> getVocabularyInPdf(
-        HttpServletRequest request,
-        @ApiParam( value = "the CV short definition/notation, e.g. AnalysisUnit" ) @PathVariable String vocabulary,
-        @ApiParam( value = "the CV SL version, e.g. 1.0" ) @PathVariable String versionNumberSl,
-        @ApiParam( value = "included language version, e.g. en-1.0_de-1.0.1, separated by _" ) @RequestParam(name = "languageVersion", required = false) String languageVersion
-    ) {
-        log.debug("REST request to get a PDF file of vocabulary {} with version {} with included versions {}", vocabulary, versionNumberSl, languageVersion);
-        return transformVocabularyToPdf(request, vocabulary, versionNumberSl, languageVersion);
-    }
-
-    /**
-     * {@code GET  /v2/vocabularies/docx/:notation/:versionNumber}
-     *  get a DOCX file of vocabulary {vocabulary} with version {versionNumberSl} with included versions {languageVersion}
-     * Hidden from Swagger due to API for CVS front-end
-     *
-     * @param vocabulary
-     * @param versionNumberSl
-     * @param languageVersion
-     * @return Vocabulary in DOCX format
-     *
-     */
-    @GetMapping("/vocabularies/docx/{vocabulary}/{versionNumberSl}")
-    @ApiOperation( value = "Get a Vocabulary in DOCX format", hidden = true  )
-    public ResponseEntity<Resource> getVocabularyInDocx(
-        HttpServletRequest request,
-        @ApiParam( value = "the CV short definition/notation, e.g. AnalysisUnit" ) @PathVariable String vocabulary,
-        @ApiParam( value = "the CV SL version, e.g. 1.0" ) @PathVariable String versionNumberSl,
-        @ApiParam( value = "included language version, e.g. en-1.0_de-1.0.1, separated by _" ) @RequestParam(name = "languageVersion", required = false) String languageVersion
-    ) {
-        log.debug("REST request to get a WORD-DOCX file of vocabulary {} with version {} with included versions {}", vocabulary, versionNumberSl, languageVersion);
-        return transformVocabularyToDocx(request, vocabulary, versionNumberSl, languageVersion);
-    }
-
-    /**
-     * {@code GET  /v2/vocabularies/skos/:notation/:versionNumber}
-     *  get a SKOS file of vocabulary {vocabulary} with version {versionNumberSl} with included versions {languageVersion}
-     *
-     * @param vocabulary controlled vocabulary
-     * @param versionNumberSl controlled vocabulary version
-     * @param languageVersion included version to be exported with format language_version e.g en-1.0_de-1.0.1
-     * @return Vocabulary in SKOS/RDF format
-     */
-    @GetMapping("/vocabularies/rdf/{vocabulary}/{versionNumberSl}")
-    @ApiOperation( value = "Get a Vocabulary in SKOS format", hidden = true, produces = ExportService.MEDIATYPE_RDF_VALUE )
-    public ResponseEntity<Resource> getVocabularyInSkos(
-        HttpServletRequest request,
-        @ApiParam( value = "the CV short definition/notation, e.g. AnalysisUnit" ) @PathVariable String vocabulary,
-        @ApiParam( value = "the CV SL version, e.g. 1.0" ) @PathVariable String versionNumberSl,
-        @ApiParam( value = "included language version, e.g. en-1.0_de-1.0.1, separated by _" ) @RequestParam(name = "languageVersion", required = false) String languageVersion
-    ) {
-        log.debug("REST request to get a SKOS-RDF file of vocabulary {} with version {} with included versions {}", vocabulary, versionNumberSl, languageVersion);
-        return transformVocabularyToRdf(request, vocabulary, versionNumberSl, languageVersion);
-    }
-
     private ResponseEntity<Resource> transformVocabularyToHtml(
         HttpServletRequest request,
         @PathVariable @ApiParam(name = "vocabulary", type = "String", value = "The vocabulary", example = "TopicClassification", required = true) String vocabulary,
@@ -778,15 +638,13 @@ public class VocabularyResourceV2 {
         @RequestParam @ApiParam(name = "languageVersion", type = "String", value = "included language version, e.g. en-1.0_de-1.0.1, separated by _", example = "en-1.0", required = false) String languageVersion) {
         String requestURL = ResourceUtils.getURLWithContextPath( request );
 
-        var outputStream = new FastByteArrayOutputStream();
-        String fileName = vocabularyService.generateVocabularyFileDownload(vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.HTML, requestURL, true, outputStream);
+        Path fileName = vocabularyService.generateVocabularyFileDownload(vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.HTML, requestURL, true);
 
-        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName);
+        headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName.getFileName());
         return ResponseEntity.ok()
             .headers(headers)
-            .body(resource);
+            .body(new FileSystemResource( fileName ));
     }
 
     private ResponseEntity<List<Object>> transformVocabularyToJsonLd(String vocabulary, String versionNumberSl, String languageVersion) {
@@ -797,52 +655,6 @@ public class VocabularyResourceV2 {
         List<Object> vocabularyJsonLds = new ArrayList<>(vocabularyJsonLdMap);
 
         return ResponseEntity.ok().body(vocabularyJsonLds);
-    }
-
-    private ResponseEntity<Resource> transformVocabularyToPdf(
-        HttpServletRequest request,
-        @PathVariable @ApiParam("the CV short definition/notation, e.g. AnalysisUnit") String vocabulary,
-        @PathVariable @ApiParam("the CV SL version, e.g. 1.0") String versionNumberSl,
-        @RequestParam(name = "languageVersion", required = false) @ApiParam("included language version, e.g. en-1.0_de-1.0.1, separated by _") String languageVersion) {
-        String requestURL = ResourceUtils.getURLWithContextPath( request );
-
-        var outputStream = new FastByteArrayOutputStream();
-        String fileName = vocabularyService.generateVocabularyFileDownload(vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.PDF, requestURL, true, outputStream );
-
-        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName );
-        return ResponseEntity.ok()
-            .headers(headers)
-            .body(resource);
-    }
-
-    private ResponseEntity<Resource> transformVocabularyToDocx(
-        HttpServletRequest request,
-        @PathVariable @ApiParam("the CV short definition/notation, e.g. AnalysisUnit") String vocabulary,
-        @PathVariable @ApiParam("the CV SL version, e.g. 1.0") String versionNumberSl,
-        @RequestParam(name = "languageVersion", required = false) @ApiParam("included language version, e.g. en-1.0_de-1.0.1, separated by _") String languageVersion) {
-        String requestURL = ResourceUtils.getURLWithContextPath( request );
-
-        var outputStream = new FastByteArrayOutputStream();
-        String fileName = vocabularyService.generateVocabularyFileDownload( vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.WORD, requestURL, true, outputStream );
-
-        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName );
-        return ResponseEntity.ok().headers(headers).body(resource);
-    }
-
-    private ResponseEntity<Resource> transformVocabularyToRdf(HttpServletRequest request, String vocabulary, String versionNumberSl, String languageVersion) {
-        String requestURL = ResourceUtils.getURLWithContextPath( request );
-
-        var outputStream = new FastByteArrayOutputStream();
-        String fileName = vocabularyService.generateVocabularyFileDownload( vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.SKOS, requestURL, true, outputStream );
-
-        InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName );
-        return ResponseEntity.ok().headers(headers).contentType( ExportService.MEDIATYPE_RDF).body(resource);
     }
 
     /**
@@ -911,11 +723,11 @@ public class VocabularyResourceV2 {
                 Map<String, String> versionMap = langMap.computeIfAbsent(
                     version.getLanguage() + "(" + version.getItemType() + ")", k -> new LinkedHashMap<>() );
                 versionMap.put( version.getNumber().toString(),
-                    ResourceUtils.getBasePath(request) + "v2/vocabularies/" + version.getNotation() + "/" +
+                    request.getContextPath() + "/" + "v2/vocabularies/" + version.getNotation() + "/" +
                         version.getNumber().getBasePatchVersion() + "?languageVersion=" + version.getLanguage() + "-" + version.getNumber());
                 for (Map<String, Object> versionHistory : version.getVersionHistories()) {
                     versionMap.put( versionHistory.get(VERSION).toString(),
-                        ResourceUtils.getBasePath(request) + "v2/vocabularies/" + version.getNotation() + "/" +
+                        request.getContextPath() + "/" + "v2/vocabularies/" + version.getNotation() + "/" +
                             VersionUtils.getSlVersionNumber(versionHistory.get(VERSION).toString())  +
                             "?languageVersion=" + version.getLanguage() + "-" + versionHistory.get(VERSION).toString());
                 }

--- a/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
@@ -604,7 +604,7 @@ public class VocabularyResourceV2 {
      */
     @GetMapping(
         value="/vocabularies/{vocabulary}/{versionNumberSl}",
-        produces = { ResourceUtils.MEDIATYPE_RDF_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE }
+        produces = { ExportService.MEDIATYPE_RDF_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE }
     )
     @ApiOperation( value = "Get a Vocabulary in Skos RDF file" )
     public ResponseEntity<Resource> getVocabularySkosRdf(
@@ -760,7 +760,7 @@ public class VocabularyResourceV2 {
      * @return Vocabulary in SKOS/RDF format
      */
     @GetMapping("/vocabularies/rdf/{vocabulary}/{versionNumberSl}")
-    @ApiOperation( value = "Get a Vocabulary in SKOS format", hidden = true, produces = ResourceUtils.MEDIATYPE_RDF_VALUE )
+    @ApiOperation( value = "Get a Vocabulary in SKOS format", hidden = true, produces = ExportService.MEDIATYPE_RDF_VALUE )
     public ResponseEntity<Resource> getVocabularyInSkos(
         HttpServletRequest request,
         @ApiParam( value = "the CV short definition/notation, e.g. AnalysisUnit" ) @PathVariable String vocabulary,
@@ -779,7 +779,7 @@ public class VocabularyResourceV2 {
         String requestURL = ResourceUtils.getURLWithContextPath( request );
 
         var outputStream = new FastByteArrayOutputStream();
-        String fileName = vocabularyService.generateVocabularyPublishFileDownload(vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.HTML, requestURL, outputStream);
+        String fileName = vocabularyService.generateVocabularyFileDownload(vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.HTML, requestURL, true, outputStream);
 
         InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
@@ -807,7 +807,7 @@ public class VocabularyResourceV2 {
         String requestURL = ResourceUtils.getURLWithContextPath( request );
 
         var outputStream = new FastByteArrayOutputStream();
-        String fileName = vocabularyService.generateVocabularyPublishFileDownload(vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.PDF, requestURL, outputStream );
+        String fileName = vocabularyService.generateVocabularyFileDownload(vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.PDF, requestURL, true, outputStream );
 
         InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
@@ -825,7 +825,7 @@ public class VocabularyResourceV2 {
         String requestURL = ResourceUtils.getURLWithContextPath( request );
 
         var outputStream = new FastByteArrayOutputStream();
-        String fileName = vocabularyService.generateVocabularyPublishFileDownload( vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.WORD, requestURL, outputStream );
+        String fileName = vocabularyService.generateVocabularyFileDownload( vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.WORD, requestURL, true, outputStream );
 
         InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
@@ -837,12 +837,12 @@ public class VocabularyResourceV2 {
         String requestURL = ResourceUtils.getURLWithContextPath( request );
 
         var outputStream = new FastByteArrayOutputStream();
-        String fileName = vocabularyService.generateVocabularyPublishFileDownload( vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.SKOS, requestURL, outputStream );
+        String fileName = vocabularyService.generateVocabularyFileDownload( vocabulary, versionNumberSl, languageVersion, ExportService.DownloadType.SKOS, requestURL, true, outputStream );
 
         InputStreamResource resource = new InputStreamResource(outputStream.getInputStream());
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName );
-        return ResponseEntity.ok().headers(headers).contentType(ResourceUtils.MEDIATYPE_RDF).body(resource);
+        return ResponseEntity.ok().headers(headers).contentType( ExportService.MEDIATYPE_RDF).body(resource);
     }
 
     /**

--- a/src/main/java/eu/cessda/cvs/web/rest/utils/ResourceUtils.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/utils/ResourceUtils.java
@@ -23,7 +23,6 @@ import eu.cessda.cvs.service.search.EsQueryResultDetail;
 import eu.cessda.cvs.utils.VersionUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import javax.servlet.http.HttpServletRequest;
@@ -34,9 +33,6 @@ public class ResourceUtils {
     public static final String VALUE = "@value";
     public static final String ID = "@id";
     public static final String TYPE = "@type";
-
-    public static final String MEDIATYPE_RDF_VALUE = "application/rdf+xml";
-    public static final MediaType MEDIATYPE_RDF = MediaType.parseMediaType(MEDIATYPE_RDF_VALUE);
 
     private ResourceUtils(){}
 

--- a/src/main/java/eu/cessda/cvs/web/rest/utils/ResourceUtils.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/utils/ResourceUtils.java
@@ -44,17 +44,6 @@ public class ResourceUtils {
         return ResponseEntity.ok().headers(headers).body(compareVersions);
     }
 
-    /**
-     * Get server base path from the Servlet request
-     * @param request
-     * @return
-     */
-    public static String getBasePath(HttpServletRequest request) {
-        if( request.getScheme().equals( "http" ) && request.getServerPort() != 80)
-            return request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath() + "/";
-        return request.getScheme() + "://" + request.getServerName() + request.getContextPath() + "/";
-    }
-
     public static List<Map<String, Object>> convertVocabularyDtoToJsonLdSkosMos(VocabularyDTO vocabularyDTO, Set<CodeDTO> codeDtos, Set<String> languages){
         List<Map<String, Object>> vocabularyJsonLds = new ArrayList<>();
         String lang = "en";

--- a/src/main/webapp/app/editor/editor.service.ts
+++ b/src/main/webapp/app/editor/editor.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 import { SERVER_API_URL } from 'app/app.constants';
@@ -115,10 +115,11 @@ export class EditorService {
     return this.http.get<string[]>(`${this.resourceEditorVocabularyUrl}/compare-prev/${id}`, { observe: 'response' });
   }
 
-  downloadVocabularyFile(notation: string, slNumber: string, downloadType: string, req?: any): Observable<Blob> {
+  downloadVocabularyFile(notation: string, slNumber: string, mimeType: string, req?: any): Observable<Blob> {
     const options = createRequestOption(req);
-    return this.http.get(`${this.resourceDownloadUrl}/${downloadType}/${notation}/${slNumber}`, {
+    return this.http.get(`${this.resourceDownloadUrl}/${notation}/${slNumber}`, {
       params: options,
+      headers: new HttpHeaders({ accept: mimeType }),
       responseType: 'blob',
     });
   }

--- a/src/main/webapp/app/entities/metadata-field/metadata-field.service.ts
+++ b/src/main/webapp/app/entities/metadata-field/metadata-field.service.ts
@@ -61,9 +61,10 @@ export class MetadataFieldService {
     return this.http.get<MetadataField>(`${this.resourceUrl}/metadata-key/${metadataKey}`, { observe: 'response' });
   }
 
-  downloadMetadataFile(metadataKey: string, downloadType: string): Observable<Blob> {
-    return this.http.get(`${this.resourceUrl}/download-${downloadType}/${metadataKey}`, {
+  downloadMetadataFile(metadataKey: string, mimeType: string): Observable<Blob> {
+    return this.http.get(`${this.resourceUrl}/download/${metadataKey}`, {
       responseType: 'blob',
+      headers: { accept: mimeType },
     });
   }
 }

--- a/src/main/webapp/app/home/home.service.ts
+++ b/src/main/webapp/app/home/home.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 import { SERVER_API_URL } from 'app/app.constants';
@@ -71,10 +71,11 @@ export class HomeService {
     return this.http.get<Vocabulary>(`${this.resourceDownloadUrl}/${notation}/latest`, { params: options, observe: 'response' });
   }
 
-  downloadVocabularyFile(notation: string, slNumber: string, downloadType: string, req?: Record<string, string>): Observable<Blob> {
+  downloadVocabularyFile(notation: string, slNumber: string, mimeType: string, req?: Record<string, string>): Observable<Blob> {
     const options = createRequestOption(req);
-    return this.http.get(`${this.resourceDownloadUrl}/${downloadType}/${notation}/${slNumber}`, {
+    return this.http.get(`${this.resourceDownloadUrl}/${notation}/${slNumber}`, {
       params: options,
+      headers: new HttpHeaders({ accept: mimeType }),
       responseType: 'blob',
     });
   }

--- a/src/main/webapp/app/shared/custom-page/custom-page.component.html
+++ b/src/main/webapp/app/shared/custom-page/custom-page.component.html
@@ -79,13 +79,13 @@
                 <jhi-alert-error></jhi-alert-error>
                 <jhi-alert></jhi-alert>
                 <div class="w-100" *ngIf="pageType !== 'about'">
-                    <button class="btn btn-sm float-right" (click)="downloadAsFile('pdf')" ngbTooltip="Download API documentation as PDF">
+                    <button class="btn btn-sm float-right" (click)="downloadAsFile({ extension: 'pdf', mimeType: 'application/pdf' })" ngbTooltip="Download API documentation as PDF">
                         <fa-icon *ngIf="!generatingFile" icon="file-pdf">PDF</fa-icon>
                         <fa-icon *ngIf="generatingFile"[icon]="'circle-notch'" [spin]="true"></fa-icon>
                     </button>&nbsp;&nbsp;&nbsp;
                 </div>
 
-                <button *ngIf="enableDocxExport" class="btn btn-sm float-right" (click)="downloadAsFile('word')" ngbTooltip="Download API documentation as Word Docx">
+                <button *ngIf="enableDocxExport" class="btn btn-sm float-right" (click)="downloadAsFile({ extension: 'docx', mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' })" ngbTooltip="Download API documentation as Word Docx">
                     <fa-icon *ngIf="!generatingFile" icon="file-word">Word</fa-icon>
                     <fa-icon *ngIf="generatingFile"[icon]="'circle-notch'" [spin]="true"></fa-icon>
                 </button>

--- a/src/main/webapp/app/shared/custom-page/custom-page.component.ts
+++ b/src/main/webapp/app/shared/custom-page/custom-page.component.ts
@@ -24,6 +24,7 @@ import { Subscription } from 'rxjs';
 import { JhiEventManager } from 'ng-jhipster';
 import { ActivatedRoute } from '@angular/router';
 import { FileUploadService } from 'app/shared/upload/file-upload.service';
+import { FileFormat } from 'app/shared/vocabulary-download/FileFormat';
 
 @Component({
   selector: 'jhi-custom-page',
@@ -141,17 +142,13 @@ export class CustomPageComponent implements OnInit, OnDestroy {
     );
   }
 
-  downloadAsFile(format: string): void {
+  downloadAsFile(format: FileFormat): void {
     if (this.generatingFile) {
       return;
     }
     this.generatingFile = true;
-    this.metadataFieldService.downloadMetadataFile(this.metadataKey, format).subscribe((res: Blob) => {
-      this.generateDownloadFile(
-        res,
-        format === 'pdf' ? 'application/pdf' : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-        format === 'pdf' ? 'pdf' : 'docx',
-      );
+    this.metadataFieldService.downloadMetadataFile(this.metadataKey, format.mimeType).subscribe((res: Blob) => {
+      this.generateDownloadFile(res, format.mimeType, format.extension);
     });
   }
 

--- a/src/main/webapp/app/shared/vocabulary-download/FileFormat.ts
+++ b/src/main/webapp/app/shared/vocabulary-download/FileFormat.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2017-2023 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface FileFormat {
+  extension: string;
+  mimeType: string;
+}

--- a/src/main/webapp/app/shared/vocabulary-download/vocabulary-download.component.ts
+++ b/src/main/webapp/app/shared/vocabulary-download/vocabulary-download.component.ts
@@ -22,11 +22,7 @@ import { Version } from 'app/shared/model/version.model';
 import { UntypedFormGroup } from '@angular/forms';
 import VocabularyUtil from 'app/shared/util/vocabulary-util';
 import { Router } from '@angular/router';
-
-interface FileFormat {
-  extension: string;
-  mimeType: string;
-}
+import { FileFormat } from 'app/shared/vocabulary-download/FileFormat';
 
 @Component({
   selector: 'jhi-vocabulary-download',

--- a/src/main/webapp/app/shared/vocabulary-download/vocabulary-download.component.ts
+++ b/src/main/webapp/app/shared/vocabulary-download/vocabulary-download.component.ts
@@ -23,6 +23,11 @@ import { UntypedFormGroup } from '@angular/forms';
 import VocabularyUtil from 'app/shared/util/vocabulary-util';
 import { Router } from '@angular/router';
 
+interface FileFormat {
+  extension: string;
+  mimeType: string;
+}
+
 @Component({
   selector: 'jhi-vocabulary-download',
   templateUrl: './vocabulary-download.component.html',
@@ -61,7 +66,7 @@ export class VocabularyDownloadComponent implements OnInit, AfterViewInit {
     const languages: string[] = this.getUniqueVersionLangs();
     for (let i = 0; i < languages.length; i++) {
       const versions: Version[] = this.getVersionsByLang(languages[i]);
-      if (!versions[0].number!.startsWith(this.getSlMajorMinorVersionNumber(this.slVersionNumber))) {
+      if (!versions[0].number?.startsWith(this.getSlMajorMinorVersionNumber(this.slVersionNumber))) {
         continue;
       }
       this.downloadCheckboxes[i] = languages[i] + '-' + versions[0].number;
@@ -108,15 +113,15 @@ export class VocabularyDownloadComponent implements OnInit, AfterViewInit {
   }
 
   downloadSkos(): void {
-    this.downloadEditorVocabularyFile('rdf', this.getCheckedItems(this.skosSelected), 'text/xml');
+    this.downloadEditorVocabularyFile(this.getCheckedItems(this.skosSelected), { extension: 'rdf', mimeType: 'application/rdf+xml' });
   }
 
   downloadPdf(): void {
-    this.downloadEditorVocabularyFile('pdf', this.getCheckedItems(this.pdfSelected), 'application/pdf');
+    this.downloadEditorVocabularyFile(this.getCheckedItems(this.pdfSelected), { extension: 'pdf', mimeType: 'application/pdf' });
   }
 
   downloadHtml(): void {
-    this.downloadEditorVocabularyFile('html', this.getCheckedItems(this.htmlSelected), 'text/html');
+    this.downloadEditorVocabularyFile(this.getCheckedItems(this.htmlSelected), { extension: 'html', mimeType: 'text/html' });
   }
 
   toggleSelectAll(downloadType: string, event: Event): void {
@@ -161,35 +166,34 @@ export class VocabularyDownloadComponent implements OnInit, AfterViewInit {
   }
 
   downloadDocx(): void {
-    this.downloadEditorVocabularyFile(
-      'docx',
-      this.getCheckedItems(this.docxSelected),
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    );
+    this.downloadEditorVocabularyFile(this.getCheckedItems(this.docxSelected), {
+      extension: 'docx',
+      mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    });
   }
 
-  private downloadEditorVocabularyFile(fileFormat: string, checkedItems: string, mimeType: string): void {
+  private downloadEditorVocabularyFile(checkedItems: string, fileFormat: FileFormat): void {
     if (this.appScope === AppScope.EDITOR) {
       this.editorService
-        .downloadVocabularyFile(this.notation, this.slVersionNumber, fileFormat, {
+        .downloadVocabularyFile(this.notation, this.slVersionNumber, fileFormat.mimeType, {
           lv: checkedItems,
         })
         .subscribe((res: Blob) => {
-          this.generateDownloadFile(res, mimeType, checkedItems, fileFormat);
+          this.generateDownloadFile(res, checkedItems, fileFormat);
         });
     } else {
       this.homeService
-        .downloadVocabularyFile(this.notation, this.slVersionNumber, fileFormat, {
+        .downloadVocabularyFile(this.notation, this.slVersionNumber, fileFormat.mimeType, {
           languageVersion: checkedItems,
         })
         .subscribe((res: Blob) => {
-          this.generateDownloadFile(res, mimeType, checkedItems, fileFormat);
+          this.generateDownloadFile(res, checkedItems, fileFormat);
         });
     }
   }
 
-  private generateDownloadFile(res: Blob, mimeType: string, checkedItems: string, fileFormat: string): void {
-    const newBlob = new Blob([res], { type: mimeType });
+  private generateDownloadFile(res: Blob, checkedItems: string, fileFormat: FileFormat): void {
+    const newBlob = new Blob([res], { type: fileFormat.mimeType });
     if (window.navigator && (window.navigator as any).msSaveOrOpenBlob) {
       (window.navigator as any).msSaveOrOpenBlob(newBlob);
       return;
@@ -197,7 +201,7 @@ export class VocabularyDownloadComponent implements OnInit, AfterViewInit {
     const data = window.URL.createObjectURL(newBlob);
     const link = document.createElement('a');
     link.href = data;
-    link.download = this.notation + '-' + this.slVersionNumber + '_' + checkedItems + '.' + fileFormat;
+    link.download = this.notation + '-' + this.slVersionNumber + '_' + checkedItems + '.' + fileFormat.extension;
     link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
     setTimeout(function (): void {
       window.URL.revokeObjectURL(data);

--- a/src/test/java/eu/cessda/cvs/web/rest/MetadataFieldResourceIT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/MetadataFieldResourceIT.java
@@ -19,6 +19,7 @@ import eu.cessda.cvs.CvsApp;
 import eu.cessda.cvs.domain.MetadataField;
 import eu.cessda.cvs.domain.enumeration.ObjectType;
 import eu.cessda.cvs.repository.MetadataFieldRepository;
+import eu.cessda.cvs.service.ExportService;
 import eu.cessda.cvs.service.MetadataFieldService;
 import eu.cessda.cvs.service.dto.MetadataFieldDTO;
 import eu.cessda.cvs.service.mapper.MetadataFieldMapper;
@@ -226,7 +227,8 @@ public class MetadataFieldResourceIT {
         metadataFieldRepository.saveAndFlush(metadataField);
 
         // Get the metadataField
-        restMetadataFieldMockMvc.perform( get("/api/metadata-fields/download-pdf/{metadataKey}", metadataField.getMetadataKey()) )
+        restMetadataFieldMockMvc.perform( get("/api/metadata-fields/download/{metadataKey}", metadataField.getMetadataKey())
+                .accept( MediaType.APPLICATION_PDF ))
             .andExpect(status().isOk())
             .andExpect( content().contentType( MediaType.APPLICATION_PDF ) )
             .andExpect( header().string( HttpHeaders.CONTENT_DISPOSITION, equalTo( "attachment; filename=document.pdf" ) ) );
@@ -240,9 +242,10 @@ public class MetadataFieldResourceIT {
         metadataFieldRepository.saveAndFlush(metadataField);
 
         // Get the metadataField
-        restMetadataFieldMockMvc.perform( get("/api/metadata-fields/download-word/{metadataKey}", metadataField.getMetadataKey()) )
+        restMetadataFieldMockMvc.perform( get( "/api/metadata-fields/download/{metadataKey}", metadataField.getMetadataKey() )
+                .accept( ExportService.MEDIATYPE_WORD ) )
             .andExpect(status().isOk())
-            .andExpect( content().contentType( new MediaType("application", "vnd.openxmlformats-officedocument.wordprocessingml.document" ) ) )
+            .andExpect( content().contentType( ExportService.MEDIATYPE_WORD ) )
             .andExpect( header().string( HttpHeaders.CONTENT_DISPOSITION, equalTo( "attachment; filename=document.docx" ) ) );
     }
 

--- a/src/test/java/eu/cessda/cvs/web/rest/VocabularyResourceV2IT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/VocabularyResourceV2IT.java
@@ -30,7 +30,6 @@ import eu.cessda.cvs.service.VersionService;
 import eu.cessda.cvs.service.VocabularyService;
 import eu.cessda.cvs.service.dto.VersionDTO;
 import eu.cessda.cvs.service.dto.VocabularyDTO;
-import eu.cessda.cvs.web.rest.utils.ResourceUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -241,7 +240,7 @@ class VocabularyResourceV2IT {
         MediaType.APPLICATION_XHTML_XML_VALUE,
         VocabularyResourceV2.DOCX_TYPE,
         VocabularyResourceV2.JSONLD_TYPE,
-        ResourceUtils.MEDIATYPE_RDF_VALUE,
+        ExportService.MEDIATYPE_RDF_VALUE,
     } )
     void getVocabulariesTest(String mediaType) throws Exception {
         restMockMvc.perform(get("/v2/vocabularies/" + EditorResourceIT.INIT_TITLE_EN +
@@ -299,9 +298,9 @@ class VocabularyResourceV2IT {
     void exportVocabulariesPublishedTest() throws Exception {
         // Retireve the SKOS output
         restMockMvc.perform(get("/v2/vocabularies/rdf/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
-            .accept(ResourceUtils.MEDIATYPE_RDF_VALUE))
+            .accept( ExportService.MEDIATYPE_RDF_VALUE))
             .andExpect(status().isOk())
-            .andExpect(content().contentType(ResourceUtils.MEDIATYPE_RDF_VALUE));
+            .andExpect(content().contentType( ExportService.MEDIATYPE_RDF_VALUE));
 
         // Retireve the HTML output
         restMockMvc.perform(get("/v2/vocabularies/html/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
@@ -341,9 +340,9 @@ class VocabularyResourceV2IT {
         final CharSequence charSequence = "null";
         // Retrieve the SKOS export
         restMockMvc.perform(get("/v2/vocabularies/rdf/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
-            .accept(ResourceUtils.MEDIATYPE_RDF_VALUE))
+            .accept( ExportService.MEDIATYPE_RDF_VALUE))
             .andExpect(status().isOk())
-            .andExpect(content().contentType(ResourceUtils.MEDIATYPE_RDF_VALUE));
+            .andExpect(content().contentType( ExportService.MEDIATYPE_RDF_VALUE));
 
         result = restMockMvc.perform(get("/v2/vocabularies/rdf/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)).andReturn();
         String content = result.getResponse().getContentAsString();

--- a/src/test/java/eu/cessda/cvs/web/rest/VocabularyResourceV2IT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/VocabularyResourceV2IT.java
@@ -229,7 +229,8 @@ class VocabularyResourceV2IT {
                 "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL + "?languageVersion=" + EditorResourceIT.SOURCE_LANGUAGE + "-" +
                 EditorResourceIT.INIT_VERSION_NUMBER_SL)
                 .accept(MediaType.TEXT_HTML_VALUE))
-                .andExpect(status().isTemporaryRedirect());
+                .andExpect(status().isTemporaryRedirect())
+                .andExpect( header().string( "Location", "/vocabulary/" +  EditorResourceIT.INIT_TITLE_EN + "?v=" + EditorResourceIT.INIT_VERSION_NUMBER_SL ) );
     }
 
     @ParameterizedTest
@@ -297,7 +298,7 @@ class VocabularyResourceV2IT {
     @Transactional
     void exportVocabulariesPublishedTest() throws Exception {
         // Retireve the SKOS output
-        restMockMvc.perform(get("/v2/vocabularies/rdf/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
+        restMockMvc.perform(get("/v2/vocabularies/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
             .accept( ExportService.MEDIATYPE_RDF_VALUE))
             .andExpect(status().isOk())
             .andExpect(content().contentType( ExportService.MEDIATYPE_RDF_VALUE));
@@ -321,16 +322,16 @@ class VocabularyResourceV2IT {
             .andExpect(content().contentType(VocabularyResourceV2.JSONLD_TYPE));
 
         // Retireve the PDF output
-        restMockMvc.perform(get("/v2/vocabularies/pdf/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
+        restMockMvc.perform(get("/v2/vocabularies/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
             .accept(MediaType.APPLICATION_PDF_VALUE))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_PDF_VALUE));
 
         // Retireve the DOCX output
-        restMockMvc.perform(get("/v2/vocabularies/docx/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
-            .accept(ExportService.DownloadType.WORD.getMediaType()))
+        restMockMvc.perform(get("/v2/vocabularies/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
+            .accept(ExportService.MEDIATYPE_WORD))
             .andExpect(status().isOk())
-            .andExpect(content().contentType(ExportService.DownloadType.WORD.getMediaType()));
+            .andExpect(content().contentType(ExportService.MEDIATYPE_WORD));
     }
 
     @Test
@@ -339,12 +340,12 @@ class VocabularyResourceV2IT {
         final MvcResult result;
         final CharSequence charSequence = "null";
         // Retrieve the SKOS export
-        restMockMvc.perform(get("/v2/vocabularies/rdf/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
+        restMockMvc.perform(get("/v2/vocabularies/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
             .accept( ExportService.MEDIATYPE_RDF_VALUE))
             .andExpect(status().isOk())
             .andExpect(content().contentType( ExportService.MEDIATYPE_RDF_VALUE));
 
-        result = restMockMvc.perform(get("/v2/vocabularies/rdf/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)).andReturn();
+        result = restMockMvc.perform(get("/v2/vocabularies/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)).andReturn();
         String content = result.getResponse().getContentAsString();
         assertThat(content).doesNotContain(charSequence);
     }


### PR DESCRIPTION
Generating exported instances of vocabularies is an expensive operation. Given that published vocabularies are not modified, generated exports can be stored without risk of them becoming outdated. Exporting from the vocabularies editor has not been changed.

See #926.