### PR TITLE
Implement Cache-Control headers for non-secured API endpoints

### DIFF
--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -78,6 +78,9 @@ server:
 # ===================================================================
 
 jhipster:
+  http:
+    cache: # Used by the CachingHttpHeadersFilter
+      timeToLiveInDays: 0
   cache: # Cache configuration
     ehcache: # Ehcache configuration
       time-to-live-seconds: 3600 # By default objects stay 1 hour in the cache

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -57,6 +57,11 @@ spring:
     password:
   thymeleaf:
     cache: true
+  web:
+    resources:
+      cache:
+        cache-control:
+          max-age: P30d
 
 # ===================================================================
 # To enable TLS in production, generate a certificate using:
@@ -91,9 +96,6 @@ server:
 # ===================================================================
 
 jhipster:
-  http:
-    cache: # Used by the CachingHttpHeadersFilter
-      timeToLiveInDays: 0
   cache: # Cache configuration
     ehcache: # Ehcache configuration
       time-to-live-seconds: 3600 # By default objects stay 1 hour in the cache

--- a/src/test/java/eu/cessda/cvs/config/WebConfigurerTest.java
+++ b/src/test/java/eu/cessda/cvs/config/WebConfigurerTest.java
@@ -20,6 +20,7 @@ import io.github.jhipster.config.JHipsterProperties;
 import io.github.jhipster.web.filter.CachingHttpHeadersFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockServletContext;
@@ -54,6 +55,8 @@ public class WebConfigurerTest {
 
     private JHipsterProperties props;
 
+    private WebProperties web;
+
     @BeforeEach
     public void setup() throws IOException {
         ApplicationProperties app = new ApplicationProperties( "target/classes/static" );
@@ -66,8 +69,9 @@ public class WebConfigurerTest {
 
         env = new MockEnvironment();
         props = new JHipsterProperties();
+        web = new WebProperties();
 
-        webConfigurer = new WebConfigurer(env, app, props);
+        webConfigurer = new WebConfigurer(env, app, props, web);
     }
 
     @Test


### PR DESCRIPTION
This allows browsers to store the JS components and static resources in production configurations.