### PR TITLE
Fix rendering of close buttons in modal dialogs

### DIFF
--- a/src/main/webapp/app/admin/health/health-modal.component.html
+++ b/src/main/webapp/app/admin/health/health-modal.component.html
@@ -19,10 +19,7 @@
     <h4 class="modal-title" id="showHealthLabel" *ngIf="health">
         {{ 'health.indicator.' + health.key | translate }}
     </h4>
-
-    <button aria-label="Close" data-dismiss="modal" class="close" type="button" (click)="dismiss()">
-        <span aria-hidden="true">&times;</span>
-    </button>
+    <button aria-label="Close" data-dismiss="modal" class="btn-close" type="button" (click)="dismiss()"></button>
 </div>
 
 <div class="modal-body pad">

--- a/src/main/webapp/app/admin/licence/licence-delete-dialog.component.html
+++ b/src/main/webapp/app/admin/licence/licence-delete-dialog.component.html
@@ -19,8 +19,7 @@
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
 
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/admin/licence/licence.service.ts
+++ b/src/main/webapp/app/admin/licence/licence.service.ts
@@ -48,7 +48,7 @@ export class LicenceService {
     return this.http.get<Licence[]>(this.resourceUrl, { params: options, observe: 'response' });
   }
 
-  delete(id: number): Observable<HttpResponse<{}>> {
+  delete(id: number): Observable<HttpResponse<unknown>> {
     return this.http.delete(`${this.resourceUrl}/${id}`, { observe: 'response' });
   }
 

--- a/src/main/webapp/app/admin/resolver/resolver-delete-dialog.component.html
+++ b/src/main/webapp/app/admin/resolver/resolver-delete-dialog.component.html
@@ -19,8 +19,7 @@
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
 
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html
+++ b/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html
@@ -19,7 +19,7 @@
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
 
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true" (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/agency/agency-delete-dialog.component.html
+++ b/src/main/webapp/app/agency/agency-delete-dialog.component.html
@@ -18,7 +18,7 @@
 <form *ngIf="agency && agency.id" name="deleteForm" (ngSubmit)="confirmDelete(agency.id)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true" (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/agency/agency-detail-dialog.component.html
+++ b/src/main/webapp/app/agency/agency-detail-dialog.component.html
@@ -31,9 +31,7 @@
         </div>
     </div>
 
-    <button aria-label="Close" class="close" data-dismiss="modal" type="button" (click)="clear()">
-        <span aria-hidden="true">×</span>
-    </button>
+    <button aria-label="Close" class="btn-close" data-dismiss="modal" type="button" (click)="clear()"></button>
 </div>
 <div class="modal-body">
     <p class="card-text">{{ agency.description }}</p>

--- a/src/main/webapp/app/editor/editor-cv-add-dialog.component.html
+++ b/src/main/webapp/app/editor/editor-cv-add-dialog.component.html
@@ -17,13 +17,8 @@
 -->
 <form name="cvAddForm" role="form" (ngSubmit)="save()" novalidate [formGroup]="cvAddForm">
     <div class="modal-header">
-        <div class="modal-title" style="display: flex;">
-           Add Vocabulary
-        </div>
-
-        <button aria-label="Close" class="close" data-dismiss="modal" type="button" (click)="clear()">
-            <span aria-hidden="true">×</span>
-        </button>
+        <div class="modal-title" style="display: flex;">Add Vocabulary</div>
+        <button aria-label="Close" class="btn-close" data-dismiss="modal" type="button" (click)="clear()"></button>
     </div>
     <div class="modal-body">
         <div class="row-content">

--- a/src/main/webapp/app/editor/editor-detail-code-add-edit-confirm.component.html
+++ b/src/main/webapp/app/editor/editor-detail-code-add-edit-confirm.component.html
@@ -17,9 +17,7 @@
 -->
 <div class="modal-header">
     <h4 class="modal-title">Warning - Code value changed</h4>
-    <button aria-label="Close" data-dismiss="modal" class="close" type="button" (click)="clear()">
-        <span aria-hidden="true">x</span>
-    </button>
+    <button aria-label="Close" data-dismiss="modal" class="btnclose" type="button" (click)="clear()"></button>
 </div>
 
 <div class="modal-body">

--- a/src/main/webapp/app/editor/editor-detail-code-add-edit-dialog.component.html
+++ b/src/main/webapp/app/editor/editor-detail-code-add-edit-dialog.component.html
@@ -24,9 +24,7 @@
             <span *ngIf="!isNew && !isSlForm && conceptParam.title">Edit {{versionParam.language! | vocabularyLanguageFromKey}} code translation for <strong>{{conceptParam.notation}}</strong></span>
         </div>
 
-        <button aria-label="Close" class="close" data-dismiss="modal" type="button" (click)="clear()">
-            <span aria-hidden="true">×</span>
-        </button>
+        <button aria-label="Close" class="btn-close" data-dismiss="modal" type="button" (click)="clear()"></button>
     </div>
     <div class="modal-body">
         <div class="row-content">

--- a/src/main/webapp/app/editor/editor-detail-code-csv-import-dialog.component.html
+++ b/src/main/webapp/app/editor/editor-detail-code-csv-import-dialog.component.html
@@ -20,8 +20,7 @@
         <h4 class="modal-title" #modalhead>
             <span>Import codes for <strong>{{versionParam.notation}} - {{versionParam!.language! | vocabularyLanguageFromKey}}</strong> from a CSV file.</span>
         </h4>
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="clear()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="clear()"></button>
     </div>
     <div class="modal-body">
         <jhi-alert-error></jhi-alert-error>

--- a/src/main/webapp/app/editor/editor-detail-code-delete-dialog.component.html
+++ b/src/main/webapp/app/editor/editor-detail-code-delete-dialog.component.html
@@ -21,8 +21,7 @@
             <span *ngIf="isSlForm">Confirm delete code <strong>{{conceptParam.notation}}</strong></span>
             <span *ngIf="!isSlForm">Confirm remove code translation {{versionParam!.language! | vocabularyLanguageFromKey}} from <strong>{{conceptParam.notation}}</strong></span>
         </h4>
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="clear()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="clear()"></button>
     </div>
     <div class="modal-body">
         <jhi-alert-error></jhi-alert-error>

--- a/src/main/webapp/app/editor/editor-detail-code-deprecate-dialog.component.html
+++ b/src/main/webapp/app/editor/editor-detail-code-deprecate-dialog.component.html
@@ -20,8 +20,7 @@
         <h4 class="modal-title">
             <span>Deprecation of the code <strong>{{conceptParam.notation}}</strong></span>
         </h4>
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="clear()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="clear()"></button>
     </div>
     <div class="modal-body">
         <jhi-alert-error></jhi-alert-error>

--- a/src/main/webapp/app/editor/editor-detail-code-reorder-dialog.component.html
+++ b/src/main/webapp/app/editor/editor-detail-code-reorder-dialog.component.html
@@ -20,8 +20,7 @@
         <h4 class="modal-title">
             <span>Reorder code</span>
         </h4>
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="clear()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="clear()"></button>
     </div>
     <div class="modal-body">
         <jhi-alert-error></jhi-alert-error>

--- a/src/main/webapp/app/editor/editor-detail-cv-add-edit-dialog.component.html
+++ b/src/main/webapp/app/editor/editor-detail-cv-add-edit-dialog.component.html
@@ -23,9 +23,7 @@
             <span *ngIf="!isNew">Edit {{versionParam.itemType}} <strong>{{vocabularyParam.notation}}</strong> from {{vocabularyParam.agencyName}} agency</span>
         </div>
 
-        <button aria-label="Close" class="close" data-dismiss="modal" type="button" (click)="clear()">
-            <span aria-hidden="true">×</span>
-        </button>
+        <button aria-label="Close" class="btn-close" data-dismiss="modal" type="button" (click)="clear()"></button>
     </div>
     <div class="modal-body">
         <div class="row-content">

--- a/src/main/webapp/app/editor/editor-detail-cv-comment-dialog.component.html
+++ b/src/main/webapp/app/editor/editor-detail-cv-comment-dialog.component.html
@@ -32,8 +32,7 @@
         <h4 class="modal-title">
             <span>Comments Cv <strong>{{versionParam.notation}}</strong> {{versionParam.itemType}} ({{versionParam.language}}) v.{{versionParam.number}}{{versionParam.status === 'PUBLISHED' ? '':'-'+ versionParam.status}}</span>
         </h4>
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="clear()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="clear()"></button>
     </div>
     <div class="modal-body">
         <jhi-alert-error></jhi-alert-error>

--- a/src/main/webapp/app/editor/editor-detail-cv-delete-dialog.component.html
+++ b/src/main/webapp/app/editor/editor-detail-cv-delete-dialog.component.html
@@ -23,8 +23,7 @@
                 {{ (versionParam.initialVersion === undefined || versionParam.initialVersion === versionParam.id) ? 'Vocabulary or ': '' }} SL & TLs versions <strong>{{versionParam.notation}}</strong> v.{{versionParam.number}}</span>
             <span *ngIf="deleteType === 'versionTl'">Confirm delete TL version <strong>{{versionParam.notation}}-{{versionParam.language}}</strong> v.{{versionParam.number}}</span>
         </h4>
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="clear()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="clear()"></button>
     </div>
     <div class="modal-body">
         <jhi-alert-error></jhi-alert-error>

--- a/src/main/webapp/app/editor/editor-detail-cv-forward-status-dialog.component.html
+++ b/src/main/webapp/app/editor/editor-detail-cv-forward-status-dialog.component.html
@@ -37,9 +37,7 @@
             </span>
         </div>
 
-        <button aria-label="Close" class="close" data-dismiss="modal" type="button" (click)="clear()">
-            <span aria-hidden="true">×</span>
-        </button>
+        <button aria-label="Close" class="btn-close" data-dismiss="modal" type="button" (click)="clear()"></button>
     </div>
     <div class="modal-body">
         <div class="row-content">

--- a/src/main/webapp/app/editor/editor-detail-cv-new-version-dialog.component.html
+++ b/src/main/webapp/app/editor/editor-detail-cv-new-version-dialog.component.html
@@ -20,8 +20,7 @@
         <h4 class="modal-title">
             <span>Confirm create new version from {{versionParam.itemType}} {{versionParam.language! | vocabularyLanguageFromKey}} <strong>{{vocabularyParam.notation}}</strong> {{versionParam.number}}</span>
         </h4>
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="clear()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="clear()"></button>
     </div>
     <div class="modal-body">
         <jhi-alert-error></jhi-alert-error>

--- a/src/main/webapp/app/entities/comment/comment-delete-dialog.component.html
+++ b/src/main/webapp/app/entities/comment/comment-delete-dialog.component.html
@@ -18,9 +18,7 @@
 <form *ngIf="comment && comment.id" name="deleteForm" (ngSubmit)="confirmDelete(comment.id)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
-
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/entities/concept/concept-delete-dialog.component.html
+++ b/src/main/webapp/app/entities/concept/concept-delete-dialog.component.html
@@ -18,9 +18,7 @@
 <form *ngIf="concept && concept.id" name="deleteForm" (ngSubmit)="confirmDelete(concept.id)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
-
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/entities/metadata-field/metadata-field-delete-dialog.component.html
+++ b/src/main/webapp/app/entities/metadata-field/metadata-field-delete-dialog.component.html
@@ -18,9 +18,7 @@
 <form *ngIf="metadataField && metadataField.id" name="deleteForm" (ngSubmit)="confirmDelete(metadataField.id)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
-
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/entities/metadata-value/metadata-value-delete-dialog.component.html
+++ b/src/main/webapp/app/entities/metadata-value/metadata-value-delete-dialog.component.html
@@ -18,9 +18,7 @@
 <form *ngIf="metadataValue && metadataValue.id" name="deleteForm" (ngSubmit)="confirmDelete(metadataValue.id)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
-
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/entities/user-agency/user-agency-delete-dialog.component.html
+++ b/src/main/webapp/app/entities/user-agency/user-agency-delete-dialog.component.html
@@ -18,9 +18,7 @@
 <form *ngIf="userAgency && userAgency.id" name="deleteForm" (ngSubmit)="confirmDelete(userAgency.id)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
-
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/entities/version/version-delete-dialog.component.html
+++ b/src/main/webapp/app/entities/version/version-delete-dialog.component.html
@@ -18,9 +18,7 @@
 <form *ngIf="version && version.id" name="deleteForm" (ngSubmit)="confirmDelete(version.id)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
-
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/entities/vocabulary-change/vocabulary-change-delete-dialog.component.html
+++ b/src/main/webapp/app/entities/vocabulary-change/vocabulary-change-delete-dialog.component.html
@@ -18,9 +18,7 @@
 <form *ngIf="vocabularyChange && vocabularyChange.id" name="deleteForm" (ngSubmit)="confirmDelete(vocabularyChange.id)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
-
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/entities/vocabulary/vocabulary-delete-dialog.component.html
+++ b/src/main/webapp/app/entities/vocabulary/vocabulary-delete-dialog.component.html
@@ -18,9 +18,7 @@
 <form *ngIf="vocabulary && vocabulary.id" name="deleteForm" (ngSubmit)="confirmDelete(vocabulary.id)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
-
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="cancel()">&times;</button>
+        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
     </div>
 
     <div class="modal-body">

--- a/src/main/webapp/app/shared/custom-page/custom-page.component.ts
+++ b/src/main/webapp/app/shared/custom-page/custom-page.component.ts
@@ -137,15 +137,15 @@ export class CustomPageComponent implements OnInit, OnDestroy {
   }
 
   fillSections(): void {
-    this.fileUploadService.fillMetadataWithHtmlFile(this.uploadFileName, this.metadataKey).subscribe(
-      () => {
+    this.fileUploadService.fillMetadataWithHtmlFile(this.uploadFileName, this.metadataKey).subscribe({
+      next: () => {
         this.refreshContent();
         location.reload();
       },
-      () => {
+      error: () => {
         this.uploadFileStatus = 'There is a problem!. Please try again later';
       },
-    );
+    });
   }
 
   downloadAsFile(format: FileFormat): void {

--- a/src/main/webapp/app/shared/login/login.component.html
+++ b/src/main/webapp/app/shared/login/login.component.html
@@ -17,10 +17,7 @@
 -->
 <div class="modal-header">
     <h4 class="modal-title" jhiTranslate="login.title">Sign in</h4>
-
-    <button aria-label="Close" data-dismiss="modal" class="close" type="button" (click)="activeModal.dismiss('closed')">
-        <span aria-hidden="true">x</span>
-    </button>
+    <button aria-label="Close" data-dismiss="modal" class="btn-close" type="button" (click)="activeModal.dismiss('closed')"></button>
 </div>
 
 <div class="modal-body">


### PR DESCRIPTION
Due to Bootstrap upgrades, the previous method of rendering buttons doesn't look correct. This commit replaces all modal close buttons with Bootstrap native buttons.

In many dialogs there is two close buttons, one in the header and another in the footer. We should consider which ones to keep in a separate issue.