### PR TITLE
Add the agency name to the alt text of an agency logo

### DIFF
--- a/src/main/webapp/app/shared/vocabulary-search-result/vocabulary-search-result.component.html
+++ b/src/main/webapp/app/shared/vocabulary-search-result/vocabulary-search-result.component.html
@@ -156,7 +156,7 @@
                     <div class="table-responsive">
                         <div *ngFor="let vocabulary of vocabularies; trackBy: trackNotation" class="vocab-item">
                             <div class="vocab-logo" *ngIf="vocabulary.agencyLogo !== null">
-                                <img [src]="'/content/images/agency/' + vocabulary.agencyLogo" width="120px" alt="logo"/>
+                                <img [src]="'/content/images/agency/' + vocabulary.agencyLogo" width="120px" [alt]="vocabulary.agencyName + ' logo'"/>
                             </div>
                             <div class="vocab-detail">
                                 <div class="vocab-title">


### PR DESCRIPTION
Alt text is used by screen readers and when an image cannot be loaded