### PR TITLE
Fix CORS requests failing due to the use of `jhipster.cors.allowed-origins` rather than `jhipster.cors.allowed-origin-patterns`

### DIFF
--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -87,7 +87,7 @@ jhipster:
       max-entries: 100 # Number of objects in each cache entry
   # CORS is only enabled by default with the "dev" profile, so BrowserSync can access the API
   cors:
-    allowed-origins: '*'
+    allowed-origin-patterns: '*'
     allowed-methods: '*'
     allowed-headers: '*'
     exposed-headers: 'Authorization,Link,X-Total-Count'

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -134,7 +134,8 @@ jhipster:
   clientApp:
     name: 'cvsApp'
   cors:
-    allowed-origins: '*'
+    # Allow all origins
+    allowed-origin-patterns: '*'
     # Only allow resources to be read
     allowed-methods: 'GET'
     allowed-headers: '*'


### PR DESCRIPTION
When `allowCredentials` is true, `jhipster.cors.allowed-origins` cannot be set to the wildcard `*`. This prevents CORS requests from succeeding.

This closes #1039