### PR TITLE
Fix streched agency images in the agency overview page

### DIFF
--- a/src/main/webapp/app/agency/agency.component.html
+++ b/src/main/webapp/app/agency/agency.component.html
@@ -39,7 +39,7 @@
                 <div class="card-header">
                     <div class="row">
                         <div class="col-4">
-                            <img *ngIf="agency.logopath" [src]="'/content/images/agency/' + agency.logopath" class="w-100 mh-60px" alt="{{ agency.name }} Logo" />
+                            <img *ngIf="agency.logopath" [src]="'/content/images/agency/' + agency.logopath" class="mw-100 mh-60px" alt="{{ agency.name }} Logo" />
                         </div>
                         <div class="card-title col-8">
                             <h4>{{ agency.name }}</h4>

--- a/src/main/webapp/app/agency/agency.component.html
+++ b/src/main/webapp/app/agency/agency.component.html
@@ -38,10 +38,10 @@
             <div class="card">
                 <div class="card-header">
                     <div class="row">
-                        <div class="col-4">
-                            <img *ngIf="agency.logopath" [src]="'/content/images/agency/' + agency.logopath" class="mw-100 mh-60px" alt="{{ agency.name }} Logo" />
+                        <div *ngIf="agency.logopath" class="col-4">
+                            <img [src]="'/content/images/agency/' + agency.logopath" class="mw-100 mh-60px" alt="{{ agency.name }} Logo" />
                         </div>
-                        <div class="card-title col-8">
+                        <div class="card-title {{ agency.logopath && 'col-8' }}">
                             <h4>{{ agency.name }}</h4>
                             <a *ngIf="agency.link" href="{{ agency.link }}" target="_blank">
                                 <span class="fst-italic fw-bold">{{urlCleaner(agency.link)}} </span>


### PR DESCRIPTION
This was caused by the width of the agency logos being set to the full size of the container rather than using `max-width`.

This closes #1038