### PR TITLE
Replace iTextPDF html2pdf with Flying Saucer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,9 +361,9 @@
         </dependency>
         <!-- pdf creator -->
         <dependency>
-            <groupId>com.itextpdf</groupId>
-            <artifactId>html2pdf</artifactId>
-            <version>6.1.0</version>
+            <groupId>org.xhtmlrenderer</groupId>
+            <artifactId>flying-saucer-pdf</artifactId>
+            <version>9.12.0</version>
         </dependency>
         <!-- word creator -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
         <dependency>
             <groupId>org.xhtmlrenderer</groupId>
             <artifactId>flying-saucer-pdf</artifactId>
-            <version>9.12.0</version>
+            <version>9.5.2</version>
         </dependency>
         <!-- word creator -->
         <dependency>

--- a/src/main/java/eu/cessda/cvs/service/ExportService.java
+++ b/src/main/java/eu/cessda/cvs/service/ExportService.java
@@ -37,10 +37,13 @@ import org.xhtmlrenderer.layout.SharedContext;
 import org.xhtmlrenderer.pdf.ITextRenderer;
 
 import javax.xml.bind.JAXBException;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.math.BigInteger;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -151,7 +154,6 @@ public class ExportService
         writer.flush();
 	}
 
-    @SuppressWarnings( "DataFlowIssue" )
     public void createPdfFile( String contents, OutputStream outputStream ) throws IOException
     {
         // Convert document to XHTML
@@ -166,19 +168,35 @@ public class ExportService
 
         // Load custom fonts
         var fontResolver = renderer.getFontResolver();
-        fontResolver.addFont( this.getClass().getResource( "/fonts/NotoSansCJKjp-Black.otf").toString(), true );
-        fontResolver.addFont( this.getClass().getResource( "/fonts/NotoSansCJKjp-Bold.otf" ).toString(), true );
-        fontResolver.addFont( this.getClass().getResource( "/fonts/NotoSansCJKjp-DemiLight.otf" ).toString(), true );
-        fontResolver.addFont( this.getClass().getResource( "/fonts/NotoSansCJKjp-Light.otf" ).toString(), true );
-        fontResolver.addFont( this.getClass().getResource( "/fonts/NotoSansCJKjp-Medium.otf" ).toString(), true );
-        fontResolver.addFont( this.getClass().getResource( "/fonts/NotoSansCJKjp-Regular.otf" ).toString(), true );
-        fontResolver.addFont( this.getClass().getResource( "/fonts/NotoSansCJKjp-Thin.otf" ).toString(), true );
+        fontResolver.addFont( getFontPath( "/fonts/NotoSansCJKjp-Black.otf" ), true );
+        fontResolver.addFont( getFontPath( "/fonts/NotoSansCJKjp-Bold.otf" ), true );
+        fontResolver.addFont( getFontPath( "/fonts/NotoSansCJKjp-DemiLight.otf" ), true );
+        fontResolver.addFont( getFontPath( "/fonts/NotoSansCJKjp-Light.otf" ), true );
+        fontResolver.addFont( getFontPath( "/fonts/NotoSansCJKjp-Medium.otf" ), true );
+        fontResolver.addFont( getFontPath( "/fonts/NotoSansCJKjp-Regular.otf" ), true );
+        fontResolver.addFont( getFontPath( "/fonts/NotoSansCJKjp-Thin.otf" ), true );
 
         // Generate the PDF
         renderer.setDocumentFromString(parsedHTML.html());
         renderer.layout();
         renderer.createPDF(outputStream);
 	}
+
+    @SuppressWarnings( "DataFlowIssue" )
+    private String getFontPath( String name )
+    {
+        URL fontURL = this.getClass().getResource( name );
+        try
+        {
+            File fontFile = new File( fontURL.toURI() ) ;
+            return fontFile.getPath();
+        }
+        catch ( IllegalArgumentException | URISyntaxException e )
+        {
+            // fallback
+            return fontURL.toString();
+        }
+    }
 
     public void createWordFile( String contents, OutputStream outputStream ) throws Docx4JException, JAXBException {
         // Setup font mapping

--- a/src/main/resources/templates/html/document_pdf.html
+++ b/src/main/resources/templates/html/document_pdf.html
@@ -31,9 +31,9 @@
         @media print
         {
             div.page{
-                page-break-inside: avoid;
+                break-inside: avoid;
             }
-            .pagebreak { page-break-before: always; }
+            .pagebreak { break-before: page; }
         }
     </style>
 </head>


### PR DESCRIPTION
This fixes a PDF export issue that causes exports to hang. The commit also replaces the use of deprecated CSS rules used in the PDF export.

This closes #1030