### PR TITLE
#1095: Fix `/v2/vocabularies/{vocabulary}/{versionNumberSl}` redirecting to the web application when `text/html` is requested, remove `application/xhtml+xml` support from the `/v2/vocabularies/{vocabulary}/{versionNumberSl}` endpoint

### DIFF
--- a/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
@@ -57,15 +57,14 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/v2")
 public class VocabularyResourceV2 {
+    private static final Logger log = LoggerFactory.getLogger(VocabularyResourceV2.class);
 
     public static final String ATTACHMENT_FILENAME = "attachment; filename=";
     public static final String LANGUAGE = "@language";
     public static final String ID = "@id";
     public static final String JSONLD_TYPE = "application/ld+json";
-    public static final String DOCX_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
     private static final String VERSION = "version";
-    public static final String VERSION_WITH_INCLUDED_VERSIONS = "REST request to get a JSON file of vocabulary {} with version {} with included versions {}";
-    private final Logger log = LoggerFactory.getLogger(VocabularyResourceV2.class);
+    private static final String VERSION_WITH_INCLUDED_VERSIONS = "REST request to get a JSON file of vocabulary {} with version {} with included versions {}";
 
     private final VocabularyService vocabularyService;
 

--- a/src/test/java/eu/cessda/cvs/web/rest/VocabularyResourceV2IT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/VocabularyResourceV2IT.java
@@ -221,27 +221,15 @@ class VocabularyResourceV2IT {
             .andExpect(status().isOk());
     }
 
-    @Test
-    @Transactional
-    void getVocabulariesRedirectTest() throws Exception
-    {
-        restMockMvc.perform(get("/v2/vocabularies/" + EditorResourceIT.INIT_TITLE_EN +
-                "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL + "?languageVersion=" + EditorResourceIT.SOURCE_LANGUAGE + "-" +
-                EditorResourceIT.INIT_VERSION_NUMBER_SL)
-                .accept(MediaType.TEXT_HTML_VALUE))
-                .andExpect(status().isTemporaryRedirect())
-                .andExpect( header().string( "Location", "/vocabulary/" +  EditorResourceIT.INIT_TITLE_EN + "?v=" + EditorResourceIT.INIT_VERSION_NUMBER_SL ) );
-    }
-
     @ParameterizedTest
     @Transactional
     @ValueSource( strings = {
         MediaType.APPLICATION_JSON_VALUE,
         MediaType.APPLICATION_PDF_VALUE,
-        MediaType.APPLICATION_XHTML_XML_VALUE,
-        VocabularyResourceV2.DOCX_TYPE,
+        MediaType.TEXT_HTML_VALUE,
         VocabularyResourceV2.JSONLD_TYPE,
         ExportService.MEDIATYPE_RDF_VALUE,
+        ExportService.MEDIATYPE_WORD_VALUE
     } )
     void getVocabulariesTest(String mediaType) throws Exception {
         restMockMvc.perform(get("/v2/vocabularies/" + EditorResourceIT.INIT_TITLE_EN +
@@ -292,46 +280,6 @@ class VocabularyResourceV2IT {
             .accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE));
-    }
-
-    @Test
-    @Transactional
-    void exportVocabulariesPublishedTest() throws Exception {
-        // Retireve the SKOS output
-        restMockMvc.perform(get("/v2/vocabularies/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
-            .accept( ExportService.MEDIATYPE_RDF_VALUE))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType( ExportService.MEDIATYPE_RDF_VALUE));
-
-        // Retireve the HTML output
-        restMockMvc.perform(get("/v2/vocabularies/html/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
-            .accept(MediaType.TEXT_HTML_VALUE))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.TEXT_HTML_VALUE));
-
-        // Retireve the JSON output
-        restMockMvc.perform(get("/v2/vocabularies/json/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
-            .accept(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE));
-
-        // Retireve the JSONDL output
-        restMockMvc.perform(get("/v2/vocabularies/jsonld/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
-            .accept(VocabularyResourceV2.JSONLD_TYPE))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(VocabularyResourceV2.JSONLD_TYPE));
-
-        // Retireve the PDF output
-        restMockMvc.perform(get("/v2/vocabularies/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
-            .accept(MediaType.APPLICATION_PDF_VALUE))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_PDF_VALUE));
-
-        // Retireve the DOCX output
-        restMockMvc.perform(get("/v2/vocabularies/" + EditorResourceIT.INIT_TITLE_EN + "/" + EditorResourceIT.INIT_VERSION_NUMBER_SL)
-            .accept(ExportService.MEDIATYPE_WORD))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(ExportService.MEDIATYPE_WORD));
     }
 
     @Test


### PR DESCRIPTION
The original `/v2/vocabularies/{vocabulary}/{versionNumberSl}` endpoint for `text/html` was a simple redirect controller. The frontend used to use specific `/v2/vocabularies/{format}/{vocabulary}/{versionNumberSl}` endpoints for vocabulary export, but this was changed as of #958. This behavior was not explained in the API documentation. This PR removes the redirect controller and returns the export.

This PR also removes `application/xhtml+xml` from the `/v2/vocabularies/{vocabulary}/{versionNumberSl}` as it doesn't return valid XML. It also removes the format specific endpoints as these are unused and are not part of the public API.

This closes #1095