### PR TITLE
Fix the editor not working properly due to a missing API to get unpublished versions of vocabularies

### DIFF
--- a/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
@@ -33,6 +33,7 @@ import eu.cessda.cvs.web.rest.domain.CvResult;
 import eu.cessda.cvs.web.rest.utils.ResourceUtils;
 import io.github.jhipster.web.util.HeaderUtil;
 import io.github.jhipster.web.util.PaginationUtil;
+import io.github.jhipster.web.util.ResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -122,6 +123,21 @@ public class EditorResource {
         this.metadataValueService = metadataValueService;
         this.applicationProperties = applicationProperties;
         this.vocabularyChangeService = vocabularyChangeService;
+    }
+
+    /**
+     * {@code GET  /vocabularies/:notation/:versionNumber}
+     *
+     * @param notation the notation of the vocabularyDTO to retrieve.
+     * @param versionNumber the versionNumber of the vocabularyDTO to retrieve.
+     * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the vocabularyDTO, or with status {@code 404 (Not Found)}.
+     */
+    @GetMapping("/editors/vocabularies/{notation}/{versionNumber}")
+    @PreAuthorize( "hasRole('" + USER + "')" )
+    public ResponseEntity<VocabularyDTO> getVocabularyByNotationAndVersion(@PathVariable String notation, @PathVariable String versionNumber) {
+        log.debug("REST request to get Vocabulary by notation {} and by version {}", notation, versionNumber);
+        VocabularyDTO vocabularyDTO = vocabularyService.getVocabularyByNotationAndVersion(notation, versionNumber, false);
+        return ResponseUtil.wrapOrNotFound(Optional.ofNullable( vocabularyDTO ));
     }
 
     /**

--- a/src/main/webapp/app/editor/editor.service.ts
+++ b/src/main/webapp/app/editor/editor.service.ts
@@ -33,7 +33,6 @@ import { MetadataValue } from 'app/shared/model/metadata-value.model';
 
 @Injectable({ providedIn: 'root' })
 export class EditorService {
-  public resourceVocabularyUrl = SERVER_API_URL + 'api/vocabularies';
   public resourceEditorSearchUrl = SERVER_API_URL + 'api/editors/search';
   public resourceEditorVocabularyUrl = SERVER_API_URL + 'api/editors/vocabularies';
   public resourceEditorCodeUrl = SERVER_API_URL + 'api/editors/codes';
@@ -108,7 +107,7 @@ export class EditorService {
   }
 
   getVocabulary(notation: string): Observable<HttpResponse<Vocabulary>> {
-    return this.http.get<Vocabulary>(`${this.resourceVocabularyUrl}/${notation}/latest`, { observe: 'response' });
+    return this.http.get<Vocabulary>(`${this.resourceEditorVocabularyUrl}/${notation}/latest`, { observe: 'response' });
   }
 
   getVocabularyCompare(id: number): Observable<HttpResponse<string[]>> {


### PR DESCRIPTION
When developing #1094 all unnecessary API endpoints were removed. This included the v1 vocabularies endpoint, hosted at `api/vocabularies`. The editor used this endpoint to load vocabularies that have not been published. This PR adds `api/editors/vocabularies` which reimplements the API that was removed and groups it with other editor APIs.