### PR TITLE
Update rest documentation, implement new VersionNumber string parser, other code cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,11 @@
             <version>${springfox.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>27.1-jre</version>
+        </dependency>
+        <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
         </dependency>

--- a/src/main/java/eu/cessda/cvs/config/SecurityConfiguration.java
+++ b/src/main/java/eu/cessda/cvs/config/SecurityConfiguration.java
@@ -25,12 +25,12 @@ import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.web.filter.CorsFilter;
@@ -39,7 +39,7 @@ import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 @Import(SecurityProblemSupport.class)
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration {
 
     private final TokenProvider tokenProvider;
 
@@ -57,9 +57,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         return new BCryptPasswordEncoder();
     }
 
-    @Override
-    public void configure(WebSecurity web) {
-        web.ignoring()
+    @Bean
+    public WebSecurityCustomizer configure() {
+        return web -> web.ignoring()
             .antMatchers(HttpMethod.OPTIONS, "/**")
             .antMatchers("/app/**/*.{js,html}")
             .antMatchers("/i18n/**")
@@ -69,10 +69,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     @SuppressWarnings( "ProhibitedExceptionDeclared" )
-    @Override
-    public void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain( HttpSecurity http ) throws Exception {
         // @formatter:off
-        http
+        return http
             .csrf()
             .disable()
             .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
@@ -114,7 +114,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/management/prometheus").permitAll()
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN_TECHNICAL)
         .and()
-            .apply(securityConfigurerAdapter());
+            .apply(securityConfigurerAdapter())
+        .and()
+            .build();
         // @formatter:on
     }
 

--- a/src/main/java/eu/cessda/cvs/config/audit/AuditEventPublisher.java
+++ b/src/main/java/eu/cessda/cvs/config/audit/AuditEventPublisher.java
@@ -19,7 +19,6 @@ import eu.cessda.cvs.domain.CodeSnippet;
 import eu.cessda.cvs.domain.User;
 import eu.cessda.cvs.domain.VocabularySnippet;
 import eu.cessda.cvs.service.dto.*;
-import eu.cessda.cvs.utils.VersionNumber;
 import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -181,7 +180,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware  {
                     map.put( CV_TITLE, version.getTitle() );
                     map.put( CV_LANGUAGE, version.getLanguage() );
                     map.put( CV_TYPE, version.getItemType() );
-                    map.put( CV_VERSION, VersionNumber.toString( version.getNumber() ) );
+                    map.put( CV_VERSION, String.valueOf( version.getNumber() ) );
                 }
                 if (codeSnippet.getChangeType() != null && codeSnippet.getChangeDesc() != null) {
                     map.put("code_change_type", codeSnippet.getChangeType());
@@ -199,14 +198,14 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware  {
                 map.put(CV_TITLE, version.getTitle());
                 map.put(CV_LANGUAGE, version.getLanguage());
                 map.put(CV_TYPE, version.getItemType());
-                map.put(CV_VERSION, VersionNumber.toString(version.getNumber()));
+                map.put(CV_VERSION, version.getNumber());
                 map.put(CODE_TITLE, concept.getTitle());
                 break;
             case "DEPRECATE_CODE":
                 map.put(CV_TITLE, version.getTitle());
                 map.put(CV_LANGUAGE, version.getLanguage());
                 map.put(CV_TYPE, version.getItemType());
-                map.put(CV_VERSION, VersionNumber.toString(version.getNumber()));
+                map.put(CV_VERSION, version.getNumber());
                 map.put(CODE_TITLE, concept.getTitle());
                 if (replacingConceptDTO != null) {
                     map.put("replaced_by_title", replacingConceptDTO.getTitle());
@@ -215,7 +214,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware  {
             case "REORDER_CODE":
                 map.put(CV_TITLE, version.getTitle());
                 map.put(CV_LANGUAGE, version.getLanguage());
-                map.put(CV_VERSION, VersionNumber.toString(version.getNumber()));
+                map.put(CV_VERSION, version.getNumber());
                 break;
             default:
         }
@@ -237,7 +236,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware  {
             case "DELETE_COMMENT":
                 map.put(CV_TITLE, version.getTitle());
                 map.put(CV_LANGUAGE, version.getLanguage());
-                map.put(CV_VERSION, VersionNumber.toString(version.getNumber()));
+                map.put(CV_VERSION, version.getNumber());
                 map.put("cv_comment", comment.getContent());
                 break;
             default:
@@ -278,7 +277,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware  {
                 map.put(CV_TYPE, version.getItemType());
                 map.put(CV_LANGUAGE, version.getLanguage());
                 map.put(CV_TITLE, version.getTitle());
-                map.put(CV_VERSION, VersionNumber.toString(version.getNumber()));
+                map.put(CV_VERSION, version.getNumber());
                 map.put(CV_STATUS, version.getStatus());
                 break;
             case "FORWARD_CV_SL_STATUS_READY_TO_TRANSLATE":
@@ -287,7 +286,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware  {
                 map.put(CV_TYPE, version.getItemType());
                 map.put(CV_LANGUAGE, version.getLanguage());
                 map.put(CV_TITLE, version.getTitle());
-                map.put(CV_VERSION, VersionNumber.toString(version.getNumber()));
+                map.put(CV_VERSION, version.getNumber());
                 map.put(CV_STATUS, version.getStatus());
                 if (vocabularySnippet!= null && vocabularySnippet.getVersionNotes() != null && !vocabularySnippet.getVersionNotes().isEmpty() ) {
                     map.put("CV_VERSION_notes", vocabularySnippet.getVersionNotes());
@@ -359,7 +358,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware  {
             case "DELETE_VERSION":
                 map.put(CV_TITLE, version.getTitle());
                 map.put(CV_TYPE, version.getItemType());
-                map.put(CV_VERSION, VersionNumber.toString(version.getNumber()));
+                map.put(CV_VERSION, version.getNumber());
                 map.put(CV_LANGUAGE, version.getLanguage());
                 map.put(CV_NOTATION, version.getNotation());
                 break;
@@ -422,7 +421,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware  {
             case "DELETE_TL_VOCABULARY":
                 map.put(CV_LANGUAGE, version.getLanguage());
                 map.put(CV_TITLE, version.getTitle());
-                map.put(CV_VERSION, VersionNumber.toString(version.getNumber()));
+                map.put(CV_VERSION, version.getNumber());
                 map.put(CV_TYPE, version.getItemType());
                 break;
             default:
@@ -432,7 +431,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware  {
 
     /**
      * Log LicenseResource
-     * @param auditUserString
+     * @param user
      * @param licenceDTO
      * @param licenceSnippet
      * @param action

--- a/src/main/java/eu/cessda/cvs/config/audit/AuditEventPublisher.java
+++ b/src/main/java/eu/cessda/cvs/config/audit/AuditEventPublisher.java
@@ -24,6 +24,7 @@ import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
 
 import java.util.HashMap;
 
@@ -43,8 +44,7 @@ public class AuditEventPublisher implements ApplicationEventPublisherAware  {
     public static final String CV_AGENCY_NAME = "cv_agency_name";
 
     @Override
-    public void setApplicationEventPublisher(
-            ApplicationEventPublisher publisher) {
+    public void setApplicationEventPublisher( @NonNull ApplicationEventPublisher publisher ) {
         this.publisher = publisher;
     }
 

--- a/src/main/java/eu/cessda/cvs/domain/Version.java
+++ b/src/main/java/eu/cessda/cvs/domain/Version.java
@@ -32,6 +32,7 @@ import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -41,7 +42,12 @@ import java.util.Set;
 @Entity
 @Table(name = "version")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class Version implements Serializable {
+public class Version implements Comparable<Version>, Serializable {
+
+    private static final Comparator<Version> VERSION_COMPARATOR =
+        Comparator.comparing( Version::getItemType )
+            .thenComparing( Version::getLanguage )
+            .thenComparing( Version::getNumber, Comparator.reverseOrder() );
 
     private static final long serialVersionUID = 1L;
 
@@ -649,5 +655,10 @@ public class Version implements Serializable {
             ", translateAgency='" + getTranslateAgency() + "'" +
             ", translateAgencyLink='" + getTranslateAgencyLink() + "'" +
             "}";
+    }
+
+    @Override
+    public int compareTo(Version o) {
+        return VERSION_COMPARATOR.compare(this, o);
     }
 }

--- a/src/main/java/eu/cessda/cvs/domain/Version.java
+++ b/src/main/java/eu/cessda/cvs/domain/Version.java
@@ -255,7 +255,7 @@ public class Version implements Serializable {
 
     @JsonGetter("number")
     public String getNumberAsString() {
-        return VersionNumber.toString(number);
+        return String.valueOf( number );
     }
 
     public Version number(VersionNumber number) {

--- a/src/main/java/eu/cessda/cvs/domain/search/AgencyStat.java
+++ b/src/main/java/eu/cessda/cvs/domain/search/AgencyStat.java
@@ -30,7 +30,10 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 import javax.persistence.ElementCollection;
 import javax.persistence.Id;
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Document(indexName = "agency")
@@ -138,9 +141,9 @@ public class AgencyStat implements Serializable {
         VersionNumber latestSlVersionNumber = null;
         VersionNumber latestPublishedSlVersionNumber = null;
 
-        Set<String> languages = new LinkedHashSet<>();
-        List<VersionStatusStat> versionStatusStats = new ArrayList<>();
-        List<VersionCodeStat> versionCodeStats = new ArrayList<>();
+        LinkedHashSet<String> languages = new LinkedHashSet<>();
+        ArrayList<VersionStatusStat> versionStatusStats = new ArrayList<>();
+        ArrayList<VersionCodeStat> versionCodeStats = new ArrayList<>();
 
         for (VersionDTO v : vocabularyDTO.getVersions()) {
             if( v.getItemType() == ItemType.SL ){
@@ -165,8 +168,8 @@ public class AgencyStat implements Serializable {
             }
         }
 
-        vocabStat.setCurrentVersion(VersionNumber.toString(latestSlVersionNumber));
-        vocabStat.setLatestPublishedVersion(VersionNumber.toString(latestPublishedSlVersionNumber));
+        vocabStat.setCurrentVersion(latestSlVersionNumber);
+        vocabStat.setLatestPublishedVersion(latestPublishedSlVersionNumber);
         vocabStat.setLanguages(new ArrayList<>(languages));
         vocabStat.setVersionCodeStats(versionCodeStats);
         vocabStat.setVersionStatusStats(versionStatusStats);

--- a/src/main/java/eu/cessda/cvs/domain/search/VocabStat.java
+++ b/src/main/java/eu/cessda/cvs/domain/search/VocabStat.java
@@ -15,6 +15,7 @@
  */
 package eu.cessda.cvs.domain.search;
 
+import eu.cessda.cvs.utils.VersionNumber;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
@@ -40,10 +41,10 @@ public class VocabStat implements Serializable {
     private String sourceLanguage;
 
     @Field( type = FieldType.Keyword, store = true )
-    private String currentVersion;
+    private VersionNumber currentVersion;
 
     @Field( type = FieldType.Keyword, store = true )
-    private String latestPublishedVersion;
+    private VersionNumber latestPublishedVersion;
 
     // language published
     @Field( type = FieldType.Keyword, store = true )
@@ -73,19 +74,19 @@ public class VocabStat implements Serializable {
         this.sourceLanguage = sourceLanguage;
     }
 
-    public String getCurrentVersion() {
+    public VersionNumber getCurrentVersion() {
         return currentVersion;
     }
 
-    public void setCurrentVersion(String currentVersion) {
+    public void setCurrentVersion(VersionNumber currentVersion) {
         this.currentVersion = currentVersion;
     }
 
-    public String getLatestPublishedVersion() {
+    public VersionNumber getLatestPublishedVersion() {
         return latestPublishedVersion;
     }
 
-    public void setLatestPublishedVersion(String latestPublishedVersion) {
+    public void setLatestPublishedVersion(VersionNumber latestPublishedVersion) {
         this.latestPublishedVersion = latestPublishedVersion;
     }
 

--- a/src/main/java/eu/cessda/cvs/security/SpringSecurityAuditorAware.java
+++ b/src/main/java/eu/cessda/cvs/security/SpringSecurityAuditorAware.java
@@ -17,6 +17,7 @@ package eu.cessda.cvs.security;
 
 import eu.cessda.cvs.config.Constants;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -28,6 +29,7 @@ import java.util.Optional;
 public class SpringSecurityAuditorAware implements AuditorAware<String> {
 
     @Override
+    @NonNull
     public Optional<String> getCurrentAuditor() {
         return Optional.of(SecurityUtils.getCurrentUserLogin().orElse(Constants.SYSTEM_ACCOUNT));
     }

--- a/src/main/java/eu/cessda/cvs/service/ConceptService.java
+++ b/src/main/java/eu/cessda/cvs/service/ConceptService.java
@@ -66,14 +66,4 @@ public interface ConceptService {
      * @return the list of entities.
      */
     List<ConceptDTO> findByVersion(Long versionId);
-
-    /**
-     * Search for the concept corresponding to the query.
-     *
-     * @param query the query of the search.
-     *
-     * @param pageable the pagination information.
-     * @return the list of entities.
-     */
-    Page<ConceptDTO> search(String query, Pageable pageable);
 }

--- a/src/main/java/eu/cessda/cvs/service/LicenceService.java
+++ b/src/main/java/eu/cessda/cvs/service/LicenceService.java
@@ -56,14 +56,4 @@ public interface LicenceService {
      * @param id the id of the entity.
      */
     void delete(Long id);
-
-    /**
-     * Search for the licence corresponding to the query.
-     *
-     * @param query the query of the search.
-     *
-     * @param pageable the pagination information.
-     * @return the list of entities.
-     */
-    Page<LicenceDTO> search(String query, Pageable pageable);
 }

--- a/src/main/java/eu/cessda/cvs/service/MetadataValueService.java
+++ b/src/main/java/eu/cessda/cvs/service/MetadataValueService.java
@@ -56,14 +56,4 @@ public interface MetadataValueService {
      * @param id the id of the entity.
      */
     void delete(Long id);
-
-    /**
-     * Search for the metadataValue corresponding to the query.
-     *
-     * @param query the query of the search.
-     *
-     * @param pageable the pagination information.
-     * @return the list of entities.
-     */
-    Page<MetadataValueDTO> search(String query, Pageable pageable);
 }

--- a/src/main/java/eu/cessda/cvs/service/ResolverService.java
+++ b/src/main/java/eu/cessda/cvs/service/ResolverService.java
@@ -56,14 +56,4 @@ public interface ResolverService {
      * @param id the id of the entity.
      */
     void delete(Long id);
-
-    /**
-     * Search for the resolver corresponding to the query.
-     *
-     * @param query the query of the search.
-     *
-     * @param pageable the pagination information.
-     * @return the list of entities.
-     */
-    Page<ResolverDTO> search(String query, Pageable pageable);
 }

--- a/src/main/java/eu/cessda/cvs/service/UserAgencyService.java
+++ b/src/main/java/eu/cessda/cvs/service/UserAgencyService.java
@@ -56,14 +56,4 @@ public interface UserAgencyService {
      * @param id the id of the entity.
      */
     void delete(Long id);
-
-    /**
-     * Search for the userAgency corresponding to the query.
-     *
-     * @param query the query of the search.
-     *
-     * @param pageable the pagination information.
-     * @return the list of entities.
-     */
-    Page<UserAgencyDTO> search(String query, Pageable pageable);
 }

--- a/src/main/java/eu/cessda/cvs/service/VersionService.java
+++ b/src/main/java/eu/cessda/cvs/service/VersionService.java
@@ -106,16 +106,6 @@ public interface VersionService {
     Set<VersionDTO> findAllPublishedByVocabularyAndVersionSl(Long vocabularyId, VersionNumber versionNumberSl);
 
     /**
-     * Search for the version corresponding to the query.
-     *
-     * @param query the query of the search.
-     *
-     * @param pageable the pagination information.
-     * @return the list of entities.
-     */
-    Page<VersionDTO> search(String query, Pageable pageable);
-
-    /**
      * Get list of versions by URN
      * @param urn
      * @return

--- a/src/main/java/eu/cessda/cvs/service/VocabularyChangeService.java
+++ b/src/main/java/eu/cessda/cvs/service/VocabularyChangeService.java
@@ -59,16 +59,6 @@ public interface VocabularyChangeService {
     void delete(Long id);
 
     /**
-     * Search for the vocabularyChange corresponding to the query.
-     *
-     * @param query the query of the search.
-     *
-     * @param pageable the pagination information.
-     * @return the list of entities.
-     */
-    Page<VocabularyChangeDTO> search(String query, Pageable pageable);
-
-    /**
      * Get all vocabularyChange corresponding to the version ID.
      *
      * @param versionId the ID of version.

--- a/src/main/java/eu/cessda/cvs/service/VocabularyService.java
+++ b/src/main/java/eu/cessda/cvs/service/VocabularyService.java
@@ -234,14 +234,6 @@ public interface VocabularyService {
     /**
      *
      * @param agencyId
-     * @param agencyUri
-     * @param agencyUriCode
-     */
-    //void updateVocabularyUri( Long agencyId, String agencyUri, String agencyUriCode );
-
-    /**
-     *
-     * @param agencyId
      * @param agencyLogoPath
      */
     void updateVocabularyLogo( Long agencyId, String agencyLogoPath );

--- a/src/main/java/eu/cessda/cvs/service/dto/VersionDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/VersionDTO.java
@@ -44,9 +44,13 @@ import java.util.stream.Collectors;
  * A DTO for the {@link Version} entity.
  */
 @JsonInclude( JsonInclude.Include.NON_NULL )
-public class VersionDTO implements Serializable
+public class VersionDTO implements Comparable<VersionDTO>, Serializable
 {
-    private static final long serialVersionUID = 6451702494637350395L;
+	private static final Comparator<VersionDTO> VERSION_DTO_COMPARATOR =
+		Comparator.comparing( VersionDTO::getItemType )
+			.thenComparing( VersionDTO::getLanguage )
+			.thenComparing( VersionDTO::getNumber, Comparator.reverseOrder() );
+	private static final long serialVersionUID = 6451702494637350395L;
 
     private Long id;
 
@@ -885,5 +889,10 @@ public class VersionDTO implements Serializable
 	@JsonIgnore
 	public LocalDate getLastChangeDate() {
 		return this.getStatus() == Status.PUBLISHED ? this.getPublicationDate() : this.getLastStatusChangeDate();
+	}
+
+	@Override
+	public int compareTo(VersionDTO other) {
+		return VERSION_DTO_COMPARATOR.compare(this, other);
 	}
 }

--- a/src/main/java/eu/cessda/cvs/service/dto/VersionDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/VersionDTO.java
@@ -226,7 +226,7 @@ public class VersionDTO implements Serializable
 
 	private Set<CommentDTO> comments = new LinkedHashSet<>();
 
-	private transient List<Map<String, Object>> versionHistories = new ArrayList<>();
+	private transient List<VersionHistoryDTO> versionHistories = new ArrayList<>();
 
 	public Long getId()
 	{
@@ -638,17 +638,17 @@ public class VersionDTO implements Serializable
 		return this;
 	}
 
-	public List<Map<String, Object>> getVersionHistories()
+	public List<VersionHistoryDTO> getVersionHistories()
 	{
 		return versionHistories;
 	}
 
-	public void setVersionHistories( List<Map<String, Object>> versionHistories )
+	public void setVersionHistories( List<VersionHistoryDTO> versionHistories )
 	{
 		this.versionHistories = versionHistories;
 	}
 
-	public VersionDTO addVersionHistory( Map<String, Object> vHistory )
+	public VersionDTO addVersionHistory( VersionHistoryDTO vHistory )
 	{
 		if ( this.versionHistories == null )
 			this.versionHistories = new ArrayList<>();

--- a/src/main/java/eu/cessda/cvs/service/dto/VersionDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/VersionDTO.java
@@ -142,7 +142,7 @@ public class VersionDTO implements Comparable<VersionDTO>, Serializable
 	/**
 	 * create initial SL version with vocabularyDTO
 	 *
-	 * @param vocabularyDTO
+	 * @param vocabularyDTO the source vocabulary.
 	 */
 	public VersionDTO( VocabularyDTO vocabularyDTO )
 	{

--- a/src/main/java/eu/cessda/cvs/service/dto/VersionHistoryDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/VersionHistoryDTO.java
@@ -1,0 +1,61 @@
+package eu.cessda.cvs.service.dto;
+
+import eu.cessda.cvs.utils.VersionNumber;
+
+import java.time.LocalDate;
+
+public class VersionHistoryDTO
+{
+    private final Long id;
+    private final VersionNumber version;
+    private final LocalDate publicationDate;
+    private final String versionNotes;
+    private final String versionChanges;
+    private final Long previousVersion;
+
+    public VersionHistoryDTO(
+        Long id,
+        VersionNumber version,
+        LocalDate publicationDate,
+        String versionNotes,
+        String versionChanges,
+        Long previousVersion )
+    {
+        this.id = id;
+        this.version = version;
+        this.publicationDate = publicationDate;
+        this.versionNotes = versionNotes;
+        this.versionChanges = versionChanges;
+        this.previousVersion = previousVersion;
+    }
+
+    public Long getId()
+    {
+        return id;
+    }
+
+    public VersionNumber getVersion()
+    {
+        return version;
+    }
+
+    public LocalDate getPublicationDate()
+    {
+        return publicationDate;
+    }
+
+    public String getVersionNotes()
+    {
+        return versionNotes;
+    }
+
+    public String getVersionChanges()
+    {
+        return versionChanges;
+    }
+
+    public Long getPreviousVersion()
+    {
+        return previousVersion;
+    }
+}

--- a/src/main/java/eu/cessda/cvs/service/dto/VersionHistoryDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/VersionHistoryDTO.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017-2023 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.cessda.cvs.service.dto;
 
 import eu.cessda.cvs.utils.VersionNumber;

--- a/src/main/java/eu/cessda/cvs/service/dto/VocabularyDTO.java
+++ b/src/main/java/eu/cessda/cvs/service/dto/VocabularyDTO.java
@@ -23,7 +23,6 @@ import eu.cessda.cvs.domain.enumeration.ItemType;
 import eu.cessda.cvs.domain.enumeration.Language;
 import eu.cessda.cvs.domain.enumeration.Status;
 import eu.cessda.cvs.utils.VersionNumber;
-import eu.cessda.cvs.utils.VocabularyUtils;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.Lob;
@@ -1394,7 +1393,7 @@ public class VocabularyDTO implements Serializable {
         List<VersionDTO> versionGroups = new ArrayList<>();
         List<VersionDTO> vGroups = this.versions.stream()
             .filter(v -> v.getNumber().equals(versionNumber))
-            .sorted(VocabularyUtils.VERSION_DTO_COMPARATOR)
+            .sorted()
             .collect(Collectors.toList());
 
         if( noSameLanguage ) {
@@ -1413,25 +1412,21 @@ public class VocabularyDTO implements Serializable {
     }
 
     public List<VersionDTO> getVersionsByMinorVersionNumber(VersionNumber minorVersionNumber, boolean noSameLanguage){
-        List<VersionDTO> versionGroups = new ArrayList<>();
+
         List<VersionDTO> vGroups = this.versions.stream()
             .filter(v -> v.getNumber().equalMinorVersionNumber(minorVersionNumber))
-            .sorted(VocabularyUtils.VERSION_DTO_COMPARATOR)
+            .sorted()
             .collect(Collectors.toList());
 
         if( noSameLanguage ) {
-            Set<String> langs = new HashSet<>();
+            HashMap<String, VersionDTO> versionGroups = new HashMap<>();
             for (VersionDTO vg : vGroups) {
-                if ( langs.contains( vg.getLanguage()))
-                    continue;
-                langs.add(vg.getLanguage());
-                versionGroups.add(vg);
+                versionGroups.putIfAbsent(vg.getLanguage(), vg);
             }
+            return new ArrayList<>(versionGroups.values());
         } else {
-            versionGroups = vGroups;
+            return vGroups;
         }
-
-        return versionGroups;
     }
 
     public String getSelectedLang() {
@@ -1451,8 +1446,9 @@ public class VocabularyDTO implements Serializable {
     }
 
     public VocabularyDTO addLanguage(String language) {
-        if(languages == null)
+        if (languages == null) {
             languages = new HashSet<>();
+        }
         this.languages.add(language);
         return this;
     }

--- a/src/main/java/eu/cessda/cvs/service/impl/ConceptServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/ConceptServiceImpl.java
@@ -111,9 +111,4 @@ public class ConceptServiceImpl implements ConceptService {
             .map(conceptMapper::toDto)
             .collect(Collectors.toCollection(LinkedList::new));
     }
-
-    @Override
-    public Page<ConceptDTO> search(String query, Pageable pageable) {
-        return null;
-    }
 }

--- a/src/main/java/eu/cessda/cvs/service/impl/LicenceServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/LicenceServiceImpl.java
@@ -100,9 +100,4 @@ public class LicenceServiceImpl implements LicenceService {
         log.debug("Request to delete Licence : {}", id);
         licenceRepository.deleteById(id);
     }
-
-    @Override
-    public Page<LicenceDTO> search(String query, Pageable pageable) {
-        return null;
-    }
 }

--- a/src/main/java/eu/cessda/cvs/service/impl/MetadataValueServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/MetadataValueServiceImpl.java
@@ -100,9 +100,4 @@ public class MetadataValueServiceImpl implements MetadataValueService {
         log.debug("Request to delete MetadataValue : {}", id);
         metadataValueRepository.deleteById(id);
     }
-
-    @Override
-    public Page<MetadataValueDTO> search(String query, Pageable pageable) {
-        return null;
-    }
 }

--- a/src/main/java/eu/cessda/cvs/service/impl/ResolverServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/ResolverServiceImpl.java
@@ -100,9 +100,4 @@ public class ResolverServiceImpl implements ResolverService {
         log.debug("Request to delete Resolver : {}", id);
         resolverRepository.deleteById(id);
     }
-
-    @Override
-    public Page<ResolverDTO> search(String query, Pageable pageable) {
-        return null;
-    }
 }

--- a/src/main/java/eu/cessda/cvs/service/impl/UserAgencyServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/UserAgencyServiceImpl.java
@@ -109,9 +109,4 @@ public class UserAgencyServiceImpl implements UserAgencyService {
         log.debug("Request to delete UserAgency : {}", id);
         userAgencyRepository.deleteById(id);
     }
-
-    @Override
-    public Page<UserAgencyDTO> search(String query, Pageable pageable) {
-        return null;
-    }
 }

--- a/src/main/java/eu/cessda/cvs/service/impl/VersionServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VersionServiceImpl.java
@@ -187,11 +187,6 @@ public class VersionServiceImpl implements VersionService {
     }
 
     @Override
-    public Page<VersionDTO> search(String query, Pageable pageable) {
-        return null;
-    }
-
-    @Override
     public List<VersionDTO> findByUrn(String urn) {
         log.debug("Request to get versions with URN {}", urn);
         return versionRepository.findByCanonicalUri(urn ).stream()

--- a/src/main/java/eu/cessda/cvs/service/impl/VersionServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VersionServiceImpl.java
@@ -22,7 +22,6 @@ import eu.cessda.cvs.service.VersionService;
 import eu.cessda.cvs.service.dto.VersionDTO;
 import eu.cessda.cvs.service.mapper.VersionMapper;
 import eu.cessda.cvs.utils.VersionNumber;
-import eu.cessda.cvs.utils.VocabularyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -114,13 +113,11 @@ public class VersionServiceImpl implements VersionService {
         return versionRepository
             .findAllByVocabulary(vocabularyId)
             .stream()
-            .sorted(
-                // #398 - We need to perform sorting by version number here, since at the DB level, the sorting is based on string comparison,
-                // and some methods, which rely on ordered results may fail.
-                // For instance, if not sorted correctly, the v9.9.9 would be treated as the latest version,
-                // despite there is a newer version v9.9.10.
-                VocabularyUtils.VERSION_COMPARATOR
-            )
+            // #398 - We need to perform sorting by version number here, since at the DB level, the sorting is based on string comparison,
+            // and some methods, which rely on ordered results may fail.
+            // For instance, if not sorted correctly, the v9.9.9 would be treated as the latest version,
+            // despite there is a newer version v9.9.10.
+            .sorted()
             .map(versionMapper::toDto)
             .collect(Collectors.toList());
     }
@@ -131,13 +128,11 @@ public class VersionServiceImpl implements VersionService {
         return versionRepository
             .findAllPublishedByVocabulary(vocabularyId)
             .stream()
-            .sorted(
-                // #398 - We need to perform sorting by version number here, since at the DB level, the sorting is based on string comparison,
-                // and some methods, which rely on ordered results may fail.
-                // For instance, if not sorted correctly, the v9.9.9 would be treated as the latest version,
-                // despite there is a newer version v9.9.10.
-                VocabularyUtils.VERSION_COMPARATOR
-            )
+            // #398 - We need to perform sorting by version number here, since at the DB level, the sorting is based on string comparison,
+            // and some methods, which rely on ordered results may fail.
+            // For instance, if not sorted correctly, the v9.9.9 would be treated as the latest version,
+            // despite there is a newer version v9.9.10.
+            .sorted()
             .map(versionMapper::toDto)
             .collect(Collectors.toList());
     }
@@ -148,13 +143,11 @@ public class VersionServiceImpl implements VersionService {
         return versionRepository
             .findOlderPublishedByVocabularyLanguageId(vocabularyId, languageIso, versionId)
             .stream()
-            .sorted(
-                // #398 - We need to perform sorting by version number here, since at the DB level, the sorting is based on string comparison,
-                // and some methods, which rely on ordered results may fail.
-                // For instance, if not sorted correctly, the v9.9.9 would be treated as the latest version,
-                // despite there is a newer version v9.9.10.
-                VocabularyUtils.VERSION_COMPARATOR
-            )
+            // #398 - We need to perform sorting by version number here, since at the DB level, the sorting is based on string comparison,
+            // and some methods, which rely on ordered results may fail.
+            // For instance, if not sorted correctly, the v9.9.9 would be treated as the latest version,
+            // despite there is a newer version v9.9.10.
+            .sorted()
             .map(versionMapper::toDto)
             .collect(Collectors.toList());
     }
@@ -167,13 +160,11 @@ public class VersionServiceImpl implements VersionService {
         return versionRepository
             .findAllByVocabularyIdAndVersionNumberSl(vocabularyId, slNumberPrefix)
             .stream()
-            .sorted(
-                // #398 - We need to perform sorting by version number here, since at the DB level, the sorting is based on string comparison,
-                // and some methods, which rely on ordered results may fail.
-                // For instance, if not sorted correctly, the v9.9.9 would be treated as the latest version,
-                // despite there is a newer version v9.9.10.
-                VocabularyUtils.VERSION_COMPARATOR
-            )
+            // #398 - We need to perform sorting by version number here, since at the DB level, the sorting is based on string comparison,
+            // and some methods, which rely on ordered results may fail.
+            // For instance, if not sorted correctly, the v9.9.9 would be treated as the latest version,
+            // despite there is a newer version v9.9.10.
+            .sorted()
             .map(versionMapper::toDto)
             .collect(Collectors.toList());
     }
@@ -186,13 +177,11 @@ public class VersionServiceImpl implements VersionService {
         return versionRepository
             .findAllPublishedByVocabularyIdAndVersionNumberSl( vocabularyId, slNumberPrefix )
             .stream()
-            .sorted(
-                // #398 - We need to perform sorting by version number here, since at the DB level, the sorting is based on string comparison,
-                // and some methods, which rely on ordered results may fail.
-                // For instance, if not sorted correctly, the v9.9.9 would be treated as the latest version,
-                // despite there is a newer version v9.9.10.
-                VocabularyUtils.VERSION_COMPARATOR
-            )
+            // #398 - We need to perform sorting by version number here, since at the DB level, the sorting is based on string comparison,
+            // and some methods, which rely on ordered results may fail.
+            // For instance, if not sorted correctly, the v9.9.9 would be treated as the latest version,
+            // despite there is a newer version v9.9.10.
+            .sorted()
             .map(versionMapper::toDto)
             .collect(Collectors.toCollection(LinkedHashSet::new));
     }

--- a/src/main/java/eu/cessda/cvs/service/impl/VocabularyChangeServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VocabularyChangeServiceImpl.java
@@ -104,11 +104,6 @@ public class VocabularyChangeServiceImpl implements VocabularyChangeService {
     }
 
     @Override
-    public Page<VocabularyChangeDTO> search(String query, Pageable pageable) {
-        return null;
-    }
-
-    @Override
     @Transactional(readOnly = true)
     public List<VocabularyChangeDTO> findByVersionId( Long versionId ) {
         log.debug("Request to get all VocabularyChanges by versionId {}", versionId);

--- a/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
@@ -724,8 +724,7 @@ public class VocabularyServiceImpl implements VocabularyService
 
     private void sortVocabularyVersions( List<VocabularyDTO> vocabulariesDTO ) {
         for ( VocabularyDTO vocabularyDTO : vocabulariesDTO ) {
-            LinkedHashSet<VersionDTO> sortedVersion = vocabularyDTO.getVersions().stream()
-                .sorted( VocabularyUtils.VERSION_DTO_COMPARATOR )
+            LinkedHashSet<VersionDTO> sortedVersion = vocabularyDTO.getVersions().stream().sorted()
                 .collect( Collectors.toCollection( LinkedHashSet::new ) );
             vocabularyDTO.setVersions( sortedVersion );
         }
@@ -903,10 +902,10 @@ public class VocabularyServiceImpl implements VocabularyService
         vocabulary.setAgencyLink( agency.getLink() );
 
         if ( !onlyPublished ) {
-            if ( slVersionNumber.equals( ALL ) )
+            if ( slVersionNumber.equals( ALL ) ) {
                 return vocabulary;
-            else if ( slVersionNumber.equals( LATEST ) ) {
-                final VersionDTO latestSlVersion = vocabulary.getVersions().stream().min(VocabularyUtils.VERSION_DTO_COMPARATOR).orElse( null );
+            } else if ( slVersionNumber.equals( LATEST ) ) {
+                final VersionDTO latestSlVersion = vocabulary.getVersions().stream().min(VersionDTO::compareTo).orElse( null );
                 if ( latestSlVersion != null ) {
                     slVersionNumber = latestSlVersion.getNumber().toString();
                 }
@@ -929,7 +928,7 @@ public class VocabularyServiceImpl implements VocabularyService
             findAllLatestVersion = true;
             slVersion = vocabulary.getVersions().stream()
                 .filter(v -> v.getStatus() == Status.PUBLISHED )
-                .min(VocabularyUtils.VERSION_DTO_COMPARATOR)
+                .min(VersionDTO::compareTo)
                 .map(VersionDTO::getNumber)
                 .orElseThrow();
         } else {
@@ -1704,7 +1703,7 @@ public class VocabularyServiceImpl implements VocabularyService
             for (VersionDTO versionDTO : includedVersions) {
                 latestVersionsMap.merge(versionDTO.getLanguage(), versionDTO,
                     // Select the latest version (defined by the lower result from the comparator)
-                    (r, k) -> VocabularyUtils.VERSION_DTO_COMPARATOR.compare(r, k) < 0 ? r : k
+                    (r, k) -> r.compareTo(k) < 0 ? r : k
                 );
             }
             includedVersions = new LinkedHashSet<>(latestVersionsMap.values());
@@ -1796,7 +1795,7 @@ public class VocabularyServiceImpl implements VocabularyService
         for ( Vocabulary vocabulary : vocabularies ) {
             vocabulary.setUri( VocabularyUtils.generateUri( agencyUri, vocabulary ) );
             final List<Version> versions = vocabulary.getVersions().stream()
-                    .sorted( VocabularyUtils.VERSION_COMPARATOR )
+                    .sorted()
                     .collect( Collectors.toList() );
             for ( Version version : versions ) {
                 updateUriForVersionAndConcept( agencyUri, agencyUriCode, vocabulary, version, agencyName );

--- a/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
+++ b/src/main/java/eu/cessda/cvs/service/impl/VocabularyServiceImpl.java
@@ -1620,23 +1620,26 @@ public class VocabularyServiceImpl implements VocabularyService
 
     private void addVersionHistories( VocabularyDTO vocabulary, VersionDTO version ) {
         var olderVersions = versionService.findOlderPublishedByVocabularyLanguageId( vocabulary.getId(), version.getLanguage(), version.getId() );
-        var olderVersionHistories = new ArrayList<Map<String, Object>>(olderVersions.size());
         for ( VersionDTO olderVersion : olderVersions )
         {
-            Map<String, Object> versionHistoryMap = new LinkedHashMap<>();
-            versionHistoryMap.put( "id", olderVersion.getId() );
-            versionHistoryMap.put( "version", olderVersion.getNumber() );
-            versionHistoryMap.put( "date", olderVersion.getPublicationDate().toString() );
-            versionHistoryMap.put( "note", olderVersion.getVersionNotes() );
-            versionHistoryMap.put( "changes", olderVersion.getVersionChanges() );
+            Long prevVersion = null;
             if ( olderVersion.getPreviousVersion() != null &&
                 !olderVersion.getPreviousVersion().equals( olderVersion.getId() ) )
             {
-                versionHistoryMap.put( "prevVersion", olderVersion.getPreviousVersion() );
+                prevVersion = olderVersion.getPreviousVersion();
             }
-            olderVersionHistories.add( versionHistoryMap );
+
+            var versionHistory = new VersionHistoryDTO(
+                olderVersion.getId(),
+                olderVersion.getNumber(),
+                olderVersion.getPublicationDate(),
+                olderVersion.getVersionNotes(),
+                olderVersion.getVersionChanges(),
+                prevVersion
+            );
+
+            version.addVersionHistory( versionHistory );
         }
-        version.setVersionHistories( olderVersionHistories );
     }
 
     private void generateJsonFile(ObjectMapper mapper, VocabularyDTO vocabulary, Map<String, List<VersionDTO>> slNumberVersionsMap ) {

--- a/src/main/java/eu/cessda/cvs/service/mapper/LicenceMapper.java
+++ b/src/main/java/eu/cessda/cvs/service/mapper/LicenceMapper.java
@@ -22,7 +22,7 @@ import org.mapstruct.Mapper;
 /**
  * Mapper for the entity {@link Licence} and its DTO {@link LicenceDTO}.
  */
-@Mapper(componentModel = "spring", uses = {})
+@Mapper(componentModel = "spring")
 public interface LicenceMapper extends EntityMapper<LicenceDTO, Licence> {
 
 

--- a/src/main/java/eu/cessda/cvs/service/search/EsFilter.java
+++ b/src/main/java/eu/cessda/cvs/service/search/EsFilter.java
@@ -16,10 +16,7 @@
 package eu.cessda.cvs.service.search;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class EsFilter implements Serializable {
     private static final long serialVersionUID = -3650519521378103904L;
@@ -34,9 +31,9 @@ public class EsFilter implements Serializable {
 
 	private FilterType filterType;
 	private String field;
-	// active filter
+	// active filters
 	private List<String> values = new ArrayList<>();
-	// aggregration active filter
+	// aggregation active filter
 	private Map<String, Long> filteredBucket = new LinkedHashMap<>();
 
 	// aggregation exclude active filter
@@ -61,12 +58,7 @@ public class EsFilter implements Serializable {
 		return values;
 	}
 	public void setValues(List<String> values) {
-		this.values = values;
-	}
-	public EsFilter addValue(String value) {
-		if( !this.values.contains(value) )
-			this.values.add(value);
-		return this;
+		this.values = Objects.requireNonNull(values, "values is null");
 	}
 	public Map<String, Long> getBucket() {
 		return bucket;

--- a/src/main/java/eu/cessda/cvs/service/search/EsQueryResultDetail.java
+++ b/src/main/java/eu/cessda/cvs/service/search/EsQueryResultDetail.java
@@ -51,11 +51,11 @@ public class EsQueryResultDetail implements Serializable {
     }
 
 	public EsQueryResultDetail(SearchScope searchScope) {
-        init(searchScope);
         this.searchScope = searchScope;
+        init();
     }
 
-    private void init(SearchScope searchScope) {
+    private void init() {
         if( searchScope == SearchScope.EDITORSEARCH ) {
             aggFields = new ArrayList<>(Arrays.asList( EsFilter.AGENCY_AGG, EsFilter.LANGS_AGG, EsFilter.STATUS_AGG ));
         } else {
@@ -74,8 +74,8 @@ public class EsQueryResultDetail implements Serializable {
     }
 
     public void setSearchScope(SearchScope searchScope) {
-        init(searchScope);
         this.searchScope = searchScope;
+        init();
     }
 
     public boolean isUseCustomQuery(){
@@ -112,10 +112,6 @@ public class EsQueryResultDetail implements Serializable {
 		this.page = page;
 	}
 
-	public static int getPagesize() {
-		return PAGE_SIZE;
-	}
-
 	public List<String> getAggFields() {
 		return aggFields;
 	}
@@ -145,14 +141,16 @@ public class EsQueryResultDetail implements Serializable {
 		return this;
 	}
 
-	public Optional<EsFilter> getEsFilterByField( String field) {
+	public Optional<EsFilter> getEsFilterByField( String field ) {
 		return this.esFilters.stream().filter( e -> e.getField().equals( field )).findFirst();
 	}
 
 	public boolean isAnyFilterActive() {
 		for( EsFilter esFilter : this.esFilters){
-			if( esFilter.getValues() != null && !esFilter.getValues().isEmpty())
-				return true;
+			if(!esFilter.getValues().isEmpty())
+            {
+                return true;
+            }
 		}
 		return false;
 	}

--- a/src/main/java/eu/cessda/cvs/utils/LanguageVersion.java
+++ b/src/main/java/eu/cessda/cvs/utils/LanguageVersion.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017-2023 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.cessda.cvs.utils;
+
+import eu.cessda.cvs.domain.enumeration.ItemType;
+
+import java.util.Objects;
+
+public final class LanguageVersion
+{
+    private final VersionNumber versionNumber;
+    private final String language;
+    private final ItemType itemType;
+
+    public LanguageVersion( VersionNumber versionNumber, String language, ItemType itemType )
+    {
+        this.versionNumber = versionNumber;
+        this.language = language;
+        this.itemType = itemType;
+    }
+    public VersionNumber getVersionNumber()
+    {
+        return versionNumber;
+    }
+
+    public String getLanguage()
+    {
+        return language;
+    }
+
+    public ItemType getItemType()
+    {
+        return itemType;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( !( o instanceof LanguageVersion ) ) return false;
+        LanguageVersion that = (LanguageVersion) o;
+        return Objects.equals( versionNumber, that.versionNumber ) &&
+            Objects.equals( language, that.language ) && itemType == that.itemType;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( versionNumber, language, itemType );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "LanguageVersion{" +
+            "versionNumber=" + versionNumber +
+            ", language='" + language + '\'' +
+            ", itemType=" + itemType +
+            '}';
+    }
+}

--- a/src/main/java/eu/cessda/cvs/utils/VersionNumber.java
+++ b/src/main/java/eu/cessda/cvs/utils/VersionNumber.java
@@ -30,8 +30,6 @@ import java.util.Objects;
 @JsonDeserialize(using = VersionNumber.Deserializer.class)
 public class VersionNumber implements Comparable<VersionNumber>, Serializable {
 
-    private static final Comparator<Integer> nullSafeIntegerComparator = Comparator.nullsFirst(Integer::compareTo);
-
     private static final long serialVersionUID = 2L;
 
     /**

--- a/src/main/java/eu/cessda/cvs/utils/VersionNumber.java
+++ b/src/main/java/eu/cessda/cvs/utils/VersionNumber.java
@@ -25,8 +25,6 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @JsonSerialize(using = ToStringSerializer.class)
 @JsonDeserialize(using = VersionNumber.Deserializer.class)
@@ -34,56 +32,112 @@ public class VersionNumber implements Comparable<VersionNumber>, Serializable {
 
     private static final Comparator<Integer> nullSafeIntegerComparator = Comparator.nullsFirst(Integer::compareTo);
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
-    private static final Pattern parsePattern = Pattern.compile("^\\D*+(\\d++)\\.(\\d++)(?:\\.(\\d++))?.*+$");
-
+    /**
+     * Parses a string into a version number. The string must either be a
+     * two or three part version number.
+     *
+     * @param str the string to parse.
+     * @return the version number represented by the string
+     * @throws IllegalArgumentException if the string is invalid.
+     */
     public static VersionNumber fromString(String str) {
-        if (str == null) {
-            return null;
-        }
-        Matcher m = parsePattern.matcher(str);
-        if (m.find()) {
-            int majorNumber = Integer.parseInt(m.group(1));
-            int minorNumber = Integer.parseInt(m.group(2));
-            int patchNumber = m.group(3) != null ? Integer.parseInt(m.group(3)) : 0;
-            return new VersionNumber(majorNumber, minorNumber, patchNumber);
-        } else {
+
+        // Find last dot, also implicitly checks presence of dots
+        int lastDot = str.lastIndexOf( '.' );
+
+        // There must be at least one dot, fail if missing
+        if (lastDot == -1) {
             throw new IllegalArgumentException("Illegal version number provided '" + str + "'");
         }
+
+        // Version number components
+        int[] versionArray = new int[]{-1 ,-1, -1};
+
+        // Current string index
+        int stringIndex = 0;
+
+        // Current version array index
+        int index = 0;
+
+        // While there is more of the string remaining
+        while ( stringIndex < str.length() )
+        {
+            // Find the next dot
+            int nextDotIndex = str.indexOf( '.', stringIndex );
+
+            // If nextDotIndex is -1, no more dots, read to the end of the string
+            if (nextDotIndex == -1) {
+                nextDotIndex = str.length();
+            }
+
+            try
+            {
+                // Store the component in the array
+                versionArray[index++] = Integer.parseInt( str, stringIndex, nextDotIndex, 10 );
+            }
+            catch ( NumberFormatException e )
+            {
+                throw new IllegalArgumentException("Illegal version number provided: '" + str + "': " + e.getMessage(), e);
+            }
+
+            // break on end of input
+            if (nextDotIndex == str.length() ) {
+                break;
+            }
+
+            // If next index is longer than 3, string has more than 3 components. This is not allowed.
+            if (index + 1 > 3) {
+                throw new IllegalArgumentException("Illegal version number provided '" + str + "': Unexpected part '" + str.substring( nextDotIndex ) + "'");
+            }
+
+            // Set the string to nextDotIndex index + 1 (avoid the dot)
+            stringIndex = nextDotIndex + 1;
+        }
+
+        // Check if the version number is valid
+        if (versionArray[0] == -1 || versionArray[1] == -1) {
+            throw new IllegalArgumentException("Illegal version number provided: '" + str + "'");
+        }
+
+        // Create a two or three part version number
+        if (versionArray[2] != -1) {
+            return new VersionNumber(versionArray[0], versionArray[1], versionArray[2]);
+        } else {
+            return new VersionNumber(versionArray[0], versionArray[1]);
+        }
     }
 
-    private final Integer majorNumber;
-    private final Integer minorNumber;
-    private final Integer patchNumber;
+    private final int majorNumber;
+    private final int minorNumber;
+    private final int patchNumber;
 
-    public VersionNumber() {
-        majorNumber = minorNumber = patchNumber = null;
-    }
-
-    public VersionNumber(Integer majorNumber, Integer minorNumber, Integer patchNumber) {
+    public VersionNumber(int majorNumber, int minorNumber, int patchNumber) {
         this.majorNumber = majorNumber;
         this.minorNumber = minorNumber;
         this.patchNumber = patchNumber;
     }
 
-    public VersionNumber(Integer majorNumber, Integer minorNumber) {
-        this(majorNumber, minorNumber, 0);
+    public VersionNumber(int majorNumber, int minorNumber) {
+        this.majorNumber = majorNumber;
+        this.minorNumber = minorNumber;
+        this.patchNumber = 0;
     }
 
-    public VersionNumber(VersionNumber versionNumber, Integer patchNumber) {
+    public VersionNumber(VersionNumber versionNumber, int patchNumber) {
         this(versionNumber.majorNumber, versionNumber.minorNumber, patchNumber);
     }
 
-    public Integer getMajorNumber() {
+    public int getMajorNumber() {
         return majorNumber;
     }
 
-    public Integer getMinorNumber() {
+    public int getMinorNumber() {
         return minorNumber;
     }
 
-    public Integer getPatchNumber() {
+    public int getPatchNumber() {
         return patchNumber;
     }
 
@@ -94,15 +148,11 @@ public class VersionNumber implements Comparable<VersionNumber>, Serializable {
 
     @JsonIgnore
     public VersionNumber getBasePatchVersion() {
-        return new VersionNumber(majorNumber, minorNumber, 0);
+        return new VersionNumber(majorNumber, minorNumber);
     }
 
     public String toString() {
         return majorNumber + "." + minorNumber + "." + patchNumber;
-    }
-
-    public static String toString(VersionNumber versionNumber) {
-        return versionNumber != null ? versionNumber.toString() : null;
     }
 
     public static class Deserializer extends FromStringDeserializer<VersionNumber> {
@@ -123,14 +173,14 @@ public class VersionNumber implements Comparable<VersionNumber>, Serializable {
 
     private static final Comparator<VersionNumber> minorVersionNumberComparator = Comparator
         .comparing(
-            VersionNumber::getMajorNumber, nullSafeIntegerComparator
+            VersionNumber::getMajorNumber, Integer::compareTo
         ).thenComparing(
-            VersionNumber::getMinorNumber, nullSafeIntegerComparator
+            VersionNumber::getMinorNumber, Integer::compareTo
         );
 
     private static final Comparator<VersionNumber> versionNumberComparator = minorVersionNumberComparator
         .thenComparing(
-            VersionNumber::getPatchNumber, nullSafeIntegerComparator
+            VersionNumber::getPatchNumber, Integer::compareTo
         );
 
     @Override
@@ -148,14 +198,10 @@ public class VersionNumber implements Comparable<VersionNumber>, Serializable {
 
     /**
      * Returns a new VersionNumber with the minor version number incremented by 1,
-     * and the patch version number set to 0.
-     * @implNote if minorNumber is {@code null}, it is treated as if it is 0.
+     * and the patch version number set to {@code null}.
      */
     public VersionNumber increaseMinorNumber() {
-        return new VersionNumber(majorNumber,
-            Objects.requireNonNullElse(minorNumber, 0) + 1,
-            0
-        );
+        return new VersionNumber( majorNumber, minorNumber + 1 );
     }
 
     /**
@@ -163,9 +209,7 @@ public class VersionNumber implements Comparable<VersionNumber>, Serializable {
      * @implNote if patchNumber is {@code null}, it is treated as if it is 0.
      */
     public VersionNumber increasePatchNumber() {
-        return new VersionNumber(majorNumber, minorNumber,
-            Objects.requireNonNullElse(patchNumber, 0) + 1
-        );
+        return new VersionNumber(majorNumber, minorNumber, patchNumber + 1 );
     }
 
     public VersionNumber increasePatch(VersionNumber currentSlNumber) {

--- a/src/main/java/eu/cessda/cvs/utils/VersionUtils.java
+++ b/src/main/java/eu/cessda/cvs/utils/VersionUtils.java
@@ -80,10 +80,10 @@ public class VersionUtils {
         return availableVersionUri.substring(0, availableVersionUri.indexOf( "/" + notation ));
     }
 
-    public static void appendVersionToSb(StringBuilder sb, VersionDTO versionDTO) {
-        sb.append(CV_NAME + " ").append(versionDTO.getTitle()).append("\n");
-        sb.append(CV_DEF + " ").append(versionDTO.getDefinition()).append("\n");
-        sb.append(CV_NOTES + " ").append(versionDTO.getNotes() == null ? "" : versionDTO.getNotes()).append("\n\n\n");
+    public static String appendVersionToSb(VersionDTO versionDTO) {
+        return CV_NAME + " " + versionDTO.getTitle() + "\n" +
+        CV_DEF + " " + versionDTO.getDefinition() + "\n" +
+        CV_NOTES + " " + ( versionDTO.getNotes() == null ? "" : versionDTO.getNotes() ) +"\n\n\n";
     }
 
     public static void appendConceptToSb(StringBuilder sb, ConceptDTO conceptDTO) {
@@ -98,16 +98,16 @@ public class VersionUtils {
         }
     }
 
-    public static List<String> compareCurPrevCV(VersionDTO versionDTO, VersionDTO prevVersionDTO) {
+    public static List<String> compareCurPrevCV(VersionDTO currentVersionDTO, VersionDTO prevVersionDTO) {
         // create comparison based on current version
         StringBuilder currentVersionCvSb = new StringBuilder();
         StringBuilder prevVersionCvSb = new StringBuilder();
 
-        appendVersionToSb(currentVersionCvSb, versionDTO);
-        appendVersionToSb(prevVersionCvSb, prevVersionDTO);
+        currentVersionCvSb.append( appendVersionToSb( currentVersionDTO ) );
+        prevVersionCvSb.append( appendVersionToSb( prevVersionDTO ) );
 
         // get concepts and sorted by position
-        List<ConceptDTO> currentConcepts = versionDTO.getConcepts().stream()
+        List<ConceptDTO> currentConcepts = currentVersionDTO.getConcepts().stream()
             .sorted(Comparator.comparing(ConceptDTO::getPosition)).collect(Collectors.toList());
         Set<ConceptDTO> existingConceptsInPrevAndCurrent = new HashSet<>();
         currentConcepts.forEach(currentConcept -> {

--- a/src/main/java/eu/cessda/cvs/utils/VersionUtils.java
+++ b/src/main/java/eu/cessda/cvs/utils/VersionUtils.java
@@ -15,9 +15,9 @@
  */
 package eu.cessda.cvs.utils;
 
+import eu.cessda.cvs.domain.enumeration.ItemType;
 import eu.cessda.cvs.service.dto.ConceptDTO;
 import eu.cessda.cvs.service.dto.VersionDTO;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -59,21 +59,32 @@ public class VersionUtils {
     }
 
     /**
-     * Split language version e.g. de-2.0.1 into several part
-     * @param languageVersion
+     * Split language version e.g. de-2.0.1 into several parts.
+     *
+     * @param languageVersion the language version to split.
      * @return array with 4 properties e.g. from example above "2.0", "2.0.2", "de", "TL"
      */
-    public static String[] splitLanguageVersion( String languageVersion ) {
+    public static LanguageVersion splitLanguageVersion( String languageVersion ) {
         final int lastIndexOfSpace = languageVersion.lastIndexOf('-');
-        final String language = languageVersion.substring(0, lastIndexOfSpace);
-        final String versionNumber = languageVersion.substring( lastIndexOfSpace + 1 );
-        String itemType = "SL";
-        String slNumber = versionNumber;
-        if( StringUtils.countMatches( versionNumber, ".") == 2){
-            itemType = "TL";
-            slNumber = versionNumber.substring( 0, versionNumber.lastIndexOf('.'));
+
+        if (lastIndexOfSpace == -1) {
+            throw new IllegalArgumentException("Invalid language version \"" + languageVersion + "\"");
         }
-	    return new String[]{slNumber, versionNumber, language, itemType};
+
+        // Extract language and version components
+        final String language = languageVersion.substring(0, lastIndexOfSpace);
+        var versionNumberString = languageVersion.substring( lastIndexOfSpace + 1 );
+        VersionNumber versionNumber = VersionNumber.fromString( versionNumberString );
+
+        // Determine item type - TLs will have a 3 part version number
+        ItemType itemType;
+        if( versionNumber.getPatchNumber() != 0 ){
+            itemType = ItemType.TL;
+        } else {
+            itemType = ItemType.SL;
+        }
+
+	    return new LanguageVersion(versionNumber, language, itemType);
     }
 
     public static String getBaseVersionUri( String availableVersionUri, String notation ) {

--- a/src/main/java/eu/cessda/cvs/utils/VocabularyUtils.java
+++ b/src/main/java/eu/cessda/cvs/utils/VocabularyUtils.java
@@ -45,16 +45,6 @@ public final class VocabularyUtils
 	{
 	}
 
-    public static final Comparator<VersionDTO> VERSION_DTO_COMPARATOR =
-        Comparator.comparing( VersionDTO::getItemType )
-            .thenComparing( VersionDTO::getLanguage )
-            .thenComparing( VersionDTO::getNumber, Comparator.reverseOrder() );
-
-    public static final Comparator<Version> VERSION_COMPARATOR =
-        Comparator.comparing( Version::getItemType )
-            .thenComparing( Version::getLanguage )
-            .thenComparing( Version::getNumber, Comparator.reverseOrder() );
-
 	public static VersionDTO getVersionByLangVersion( VocabularyDTO vocabularyDTO, String language, VersionNumber versionNumber )
 	{
 		return vocabularyDTO.getVersions().stream()

--- a/src/main/java/eu/cessda/cvs/utils/VocabularyUtils.java
+++ b/src/main/java/eu/cessda/cvs/utils/VocabularyUtils.java
@@ -55,10 +55,10 @@ public final class VocabularyUtils
             .thenComparing( Version::getLanguage )
             .thenComparing( Version::getNumber, Comparator.reverseOrder() );
 
-	public static VersionDTO getVersionByLangVersion( VocabularyDTO vocabularyDTO, String language, String versionNumber )
+	public static VersionDTO getVersionByLangVersion( VocabularyDTO vocabularyDTO, String language, VersionNumber versionNumber )
 	{
 		return vocabularyDTO.getVersions().stream()
-				.filter( v -> v.getLanguage().equals( language ) && v.getNumber().equals( VersionNumber.fromString( versionNumber ) ) )
+				.filter( v -> v.getLanguage().equals( language ) && v.getNumber().equals( versionNumber ) )
 				.findFirst().orElse( null );
 	}
 

--- a/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/EditorResource.java
@@ -1137,7 +1137,7 @@ public class EditorResource {
     }
 
     /**
-     * {@code GET  /search} : get all the vocabularies from elasticsearch.
+     * {@code GET  /search} : get all the vocabularies from Elasticsearch.
      *
 
      * @param q the query term.
@@ -1146,9 +1146,11 @@ public class EditorResource {
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of vocabularies in body.
      */
     @GetMapping("/editors/search")
-    public ResponseEntity<CvResult> getAllVocabularies(@RequestParam(name = "q", required = false) String q,
-                                                       @RequestParam(name = "f", required = false) String f,
-                                                       Pageable pageable) {
+    public ResponseEntity<CvResult> getAllVocabularies(
+        @RequestParam(name = "q", required = false) String q,
+        @RequestParam(name = "f", required = false) String f,
+        Pageable pageable
+    ) {
         log.debug("REST request to get a page of Vocabularies");
 
         EsQueryResultDetail esq = VocabularyUtils.prepareEsQuerySearching( q, f, pageable, SearchScope.EDITORSEARCH);

--- a/src/main/java/eu/cessda/cvs/web/rest/FileUploadResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/FileUploadResource.java
@@ -121,7 +121,6 @@ public class FileUploadResource
         return ResponseEntity.created( new URI( UPLOADED_FILE_URI + uploadedFile.getFileName() ) ).build();
     }
 
-    @SuppressWarnings( "DataFlowIssue" )
     @PostMapping( "/docx2html/{fileName}" )
     @PreAuthorize( "hasRole('" + ADMIN_CONTENT + "')")
     public ResponseEntity<Void> docx2html( @PathVariable String fileName ) throws IOException, Docx4JException, URISyntaxException

--- a/src/main/java/eu/cessda/cvs/web/rest/LicenceResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/LicenceResource.java
@@ -181,20 +181,4 @@ public class LicenceResource {
         licenceService.delete(id);
         return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, id.toString())).build();
     }
-
-    /**
-     * {@code SEARCH  /_search/licences?query=:query} : search for the licence corresponding
-     * to the query.
-     *
-     * @param query the query of the licence search.
-     * @param pageable the pagination information.
-     * @return the result of the search.
-     */
-    @GetMapping("/_search/licences")
-    public ResponseEntity<List<LicenceDTO>> searchLicences(@RequestParam String query, Pageable pageable) {
-        log.debug("REST request to search for a page of Licences for query {}", query);
-        Page<LicenceDTO> page = licenceService.search(query, pageable);
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
-        return ResponseEntity.ok().headers(headers).body(page.getContent());
-    }
 }

--- a/src/main/java/eu/cessda/cvs/web/rest/ResolverResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/ResolverResource.java
@@ -136,20 +136,4 @@ public class ResolverResource {
         resolverService.delete(id);
         return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, id.toString())).build();
     }
-
-    /**
-     * {@code SEARCH  /_search/resolvers?query=:query} : search for the resolver corresponding
-     * to the query.
-     *
-     * @param query the query of the resolver search.
-     * @param pageable the pagination information.
-     * @return the result of the search.
-     */
-    @GetMapping("/_search/resolvers")
-    public ResponseEntity<List<ResolverDTO>> searchResolvers(@RequestParam String query, Pageable pageable) {
-        log.debug("REST request to search for a page of Resolvers for query {}", query);
-        Page<ResolverDTO> page = resolverService.search(query, pageable);
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
-        return ResponseEntity.ok().headers(headers).body(page.getContent());
-    }
 }

--- a/src/main/java/eu/cessda/cvs/web/rest/UrnResolver.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/UrnResolver.java
@@ -17,9 +17,9 @@ package eu.cessda.cvs.web.rest;
 
 import eu.cessda.cvs.domain.enumeration.ItemType;
 import eu.cessda.cvs.domain.enumeration.Status;
-import eu.cessda.cvs.service.ExportService;
 import eu.cessda.cvs.service.VersionService;
 import eu.cessda.cvs.service.dto.VersionDTO;
+import io.swagger.annotations.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -31,13 +31,16 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
-import static eu.cessda.cvs.web.rest.VocabularyResourceV2.JSONLD_TYPE;
+import static eu.cessda.cvs.service.ExportService.MEDIATYPE_RDF_VALUE;
+import static eu.cessda.cvs.service.ExportService.MEDIATYPE_WORD_VALUE;
+import static eu.cessda.cvs.web.rest.utils.ResourceUtils.MEDIATYPE_JSONLD_VALUE;
 
 /**
- * REST controller for resolving URN
+ * REST controller for resolving URNs
  */
+@Api( description = "URN Resolver")
 @RestController
-@RequestMapping("/urn")
+@RequestMapping(value = "/urn" )
 public class UrnResolver {
 
     private final Logger log = LoggerFactory.getLogger(UrnResolver.class);
@@ -52,10 +55,10 @@ public class UrnResolver {
      * GET  / : redirect to resourceURL by "resolverUri or URN" resolver.
      *
      * @param urn the URN of the versionDTO to retrieve
-     * @return the ResponseEntity with status 200 (OK) and then redirect to resource URL,
-     * or with status 404 (Not Found)
+     * @return the ResponseEntity with status 302 (Found) with the location header set,
+     * or status 404 (Not Found)
      */
-    @GetMapping(value = "/{urn}", produces = { MediaType.APPLICATION_JSON_VALUE, JSONLD_TYPE, MediaType.APPLICATION_PDF_VALUE, ExportService.MEDIATYPE_WORD_VALUE, ExportService.MEDIATYPE_RDF_VALUE })
+    @GetMapping(value = "/{urn}", produces = { MediaType.APPLICATION_JSON_VALUE, MEDIATYPE_JSONLD_VALUE, MediaType.APPLICATION_PDF_VALUE, MEDIATYPE_WORD_VALUE, MEDIATYPE_RDF_VALUE })
     public ResponseEntity<Void> findUrnJsonResolver( @PathVariable(name = "urn") String urn, @RequestParam(name = "lang", required = false) String lang )
     {
         Optional<ResponseEntity<Void>> responseEntity;
@@ -89,11 +92,19 @@ public class UrnResolver {
      * GET  / : redirect to resourceURL by "resolverUri or URN" resolver.
      *
      * @param urn the URN of the versionDTO to retrieve
-     * @return the ResponseEntity with status 200 (OK) and then redirect to resource URL,
-     * or with status 404 (Not Found)
+     * @return the ResponseEntity with status 302 (Found) with the location header set,
+     * or status 404 (Not Found)
      */
-    @GetMapping("/{urn}")
-    public ResponseEntity<Void> findUrnResolver( @PathVariable(name = "urn") String urn, @RequestParam(name = "lang", required = false) String lang) {
+    @ApiOperation( value = "Resolve a URN to a vocabulary", code = 302 )
+    @ApiResponses( {
+        @ApiResponse( code = 302, message = "The resolved vocabulary" ),
+        @ApiResponse( code = 404, message = "URN unable to be resolved" )
+    } )
+    @GetMapping(value = "/{urn}")
+    public ResponseEntity<Void> findUrnResolver(
+        @ApiParam(value = "The URN of the vocabulary") @PathVariable(name = "urn") String urn,
+        @ApiParam(value = "The language of the vocabulary") @RequestParam(name = "lang", required = false) String lang
+    ) {
         log.debug("REST request to get Resolver by URI: {}", urn);
 
         Optional<ResponseEntity<Void>> responseEntity;

--- a/src/main/java/eu/cessda/cvs/web/rest/UrnResolver.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/UrnResolver.java
@@ -38,6 +38,7 @@ import static eu.cessda.cvs.web.rest.utils.ResourceUtils.MEDIATYPE_JSONLD_VALUE;
 /**
  * REST controller for resolving URNs
  */
+@SuppressWarnings( "deprecation" )
 @Api( description = "URN Resolver")
 @RestController
 @RequestMapping(value = "/urn" )

--- a/src/main/java/eu/cessda/cvs/web/rest/UserAgencyResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/UserAgencyResource.java
@@ -134,20 +134,4 @@ public class UserAgencyResource {
         userAgencyService.delete(id);
         return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, id.toString())).build();
     }
-
-    /**
-     * {@code SEARCH  /_search/user-agencies?query=:query} : search for the userAgency corresponding
-     * to the query.
-     *
-     * @param query the query of the userAgency search.
-     * @param pageable the pagination information.
-     * @return the result of the search.
-     */
-    @GetMapping("/_search/user-agencies")
-    public ResponseEntity<List<UserAgencyDTO>> searchUserAgencies(@RequestParam String query, Pageable pageable) {
-        log.debug("REST request to search for a page of UserAgencies for query {}", query);
-        Page<UserAgencyDTO> page = userAgencyService.search(query, pageable);
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
-        return ResponseEntity.ok().headers(headers).body(page.getContent());
-    }
 }

--- a/src/main/java/eu/cessda/cvs/web/rest/VersionResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/VersionResource.java
@@ -181,22 +181,6 @@ public class VersionResource {
     }
 
     /**
-     * {@code SEARCH  /_search/versions?query=:query} : search for the version corresponding
-     * to the query.
-     *
-     * @param query the query of the version search.
-     * @param pageable the pagination information.
-     * @return the result of the search.
-     */
-    @GetMapping("/_search/versions")
-    public ResponseEntity<List<VersionDTO>> searchVersions(@RequestParam String query, Pageable pageable) {
-        log.debug("REST request to search for a page of Versions for query {}", query);
-        Page<VersionDTO> page = versionService.search(query, pageable);
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
-        return ResponseEntity.ok().headers(headers).body(page.getContent());
-    }
-
-    /**
      * {@code GET  /search/languages}
      *
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of languages in body.

--- a/src/main/java/eu/cessda/cvs/web/rest/VocabularyMaintenanceResource.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/VocabularyMaintenanceResource.java
@@ -20,10 +20,11 @@ import eu.cessda.cvs.service.VocabularyService;
 import eu.cessda.cvs.web.rest.domain.Maintenance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static eu.cessda.cvs.web.rest.domain.Maintenance.Operation.*;
 
 /**
  * REST controller for managing {@link eu.cessda.cvs.domain.Agency}.
@@ -32,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/maintenance")
 public class VocabularyMaintenanceResource {
 
-    private final Logger log = LoggerFactory.getLogger(VocabularyMaintenanceResource.class);
+    private static final Logger log = LoggerFactory.getLogger(VocabularyMaintenanceResource.class);
 
     private final AgencyService agencyService;
     private final VocabularyService vocabularyService;
@@ -43,43 +44,38 @@ public class VocabularyMaintenanceResource {
     }
 
     @PostMapping("/publication/generate-json")
-    public ResponseEntity<Maintenance> getGenerateJson()
+    public Maintenance getGenerateJson()
     {
         log.debug("REST request to get a page of Vocabularies");
         final String output = vocabularyService.generateJsonAllVocabularyPublish();
-        Maintenance maintenanceOut = new Maintenance(output, "GENERATE_JSON");
-        return ResponseEntity.ok().body(maintenanceOut);
+        return new Maintenance(output, GENERATE_JSON);
     }
 
     @PostMapping("/index/agency-stats")
-    public ResponseEntity<Maintenance> indexAgencyStats() {
+    public Maintenance indexAgencyStats() {
         log.debug("REST request to index Agencies Stats");
         vocabularyService.indexAllAgencyStats();
-        Maintenance maintenanceOut = new Maintenance("Done indexing Agency Stats", "INDEX_AGENCY_STAT");
-        return ResponseEntity.ok().body( maintenanceOut);
+        return new Maintenance("Done indexing Agency Stats", INDEX_AGENCY_STAT);
     }
 
     @PostMapping("/index/vocabulary")
-    public ResponseEntity<Maintenance> indexVocabulary() {
+    public Maintenance indexVocabulary() {
         log.debug("REST request to index published Vocabularies");
         vocabularyService.indexAllPublished();
-        Maintenance maintenanceOut = new Maintenance("Done indexing published Vocabularies", "INDEX_VOCABULARY_PUBLISH");
-        return ResponseEntity.ok().body( maintenanceOut);
+        return new Maintenance("Done indexing published Vocabularies", INDEX_VOCABULARY_PUBLISH);
     }
 
     @PostMapping("/index/vocabulary/editor")
-    public ResponseEntity<Maintenance> indexVocabularyEditor() {
+    public Maintenance indexVocabularyEditor() {
         log.debug("REST request to index Vocabularies in editor");
         vocabularyService.indexAllEditor();
-        Maintenance maintenanceOut = new Maintenance("Done indexing Vocabulary Editor", "INDEX_VOCABULARY_EDITOR");
-        return ResponseEntity.ok().body(maintenanceOut);
+        return new Maintenance("Done indexing Vocabulary Editor", INDEX_VOCABULARY_EDITOR);
     }
 
     @PostMapping("/index/agency")
-    public ResponseEntity<Maintenance> indexAgency() {
+    public Maintenance indexAgency() {
         log.debug("REST request to index Agencies");
         agencyService.indexAll();
-        Maintenance maintenanceOut = new Maintenance("Done indexing Agency", "INDEX_AGENCY");
-        return ResponseEntity.ok().body(maintenanceOut);
+        return new Maintenance("Done indexing Agency", INDEX_AGENCY);
     }
 }

--- a/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
@@ -67,7 +67,6 @@ public class VocabularyResourceV2 {
     private static final Logger log = LoggerFactory.getLogger(VocabularyResourceV2.class);
 
     private static final String ATTACHMENT_FILENAME = "attachment; filename=";
-    private static final String VERSION = "version";
     private static final String VERSION_WITH_INCLUDED_VERSIONS = "REST request to get a JSON file of vocabulary {} with version {} with included versions {}";
 
     private final VocabularyService vocabularyService;
@@ -94,8 +93,8 @@ public class VocabularyResourceV2 {
     @GetMapping("/search")
     @ApiOperation( value = "Searching the vocabularies", hidden = true )
     public ResponseEntity<CvResult> searchVocabularies(
-        @ApiParam( value = "the query, e.g. Family" ) @RequestParam(name = "q", required = false) String q,
-        @ApiParam( value = "the filter, e.g agency:DDI Alliance;language:en" ) @RequestParam(name = "f", required = false) String f,
+        @ApiParam( value = "the query", example = "Family") @RequestParam(name = "q", required = false) String q,
+        @ApiParam( value = "the filter", example = "agency:DDI Alliance;language:en") @RequestParam(name = "f", required = false) String f,
         Pageable pageable) {
         log.debug("REST request search vocabulary by query");
         EsQueryResultDetail esq = VocabularyUtils.prepareEsQuerySearching(q, f, pageable, SearchScope.PUBLICATIONSEARCH);

--- a/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
@@ -20,49 +20,52 @@ import eu.cessda.cvs.domain.enumeration.Status;
 import eu.cessda.cvs.service.ExportService;
 import eu.cessda.cvs.service.ResourceNotFoundException;
 import eu.cessda.cvs.service.VocabularyService;
-import eu.cessda.cvs.service.dto.CodeDTO;
-import eu.cessda.cvs.service.dto.ConceptDTO;
-import eu.cessda.cvs.service.dto.VersionDTO;
-import eu.cessda.cvs.service.dto.VocabularyDTO;
+import eu.cessda.cvs.service.dto.*;
 import eu.cessda.cvs.service.search.EsQueryResultDetail;
 import eu.cessda.cvs.service.search.SearchScope;
+import eu.cessda.cvs.utils.VersionNumber;
 import eu.cessda.cvs.utils.VersionUtils;
 import eu.cessda.cvs.utils.VocabularyUtils;
 import eu.cessda.cvs.web.rest.domain.CvResult;
 import eu.cessda.cvs.web.rest.utils.ResourceUtils;
 import io.github.jhipster.web.util.PaginationUtil;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.constraints.Max;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static eu.cessda.cvs.web.rest.utils.ResourceUtils.MEDIATYPE_JSONLD;
+import static eu.cessda.cvs.web.rest.utils.ResourceUtils.MEDIATYPE_JSONLD_VALUE;
 
 
 /**
  * REST controller for managing {@link Vocabulary}.
  */
+@SuppressWarnings( "deprecation" )
+@Api( description = "Vocabulary Resource API (v2)" )
 @RestController
-@RequestMapping("/v2")
+@RequestMapping( value ="/v2", name = "Vocabulary Resource API (v2)" )
+@Validated
 public class VocabularyResourceV2 {
     private static final Logger log = LoggerFactory.getLogger(VocabularyResourceV2.class);
 
-    public static final String ATTACHMENT_FILENAME = "attachment; filename=";
-    public static final String LANGUAGE = "@language";
-    public static final String ID = "@id";
-    public static final String JSONLD_TYPE = "application/ld+json";
+    private static final String ATTACHMENT_FILENAME = "attachment; filename=";
     private static final String VERSION = "version";
     private static final String VERSION_WITH_INCLUDED_VERSIONS = "REST request to get a JSON file of vocabulary {} with version {} with included versions {}";
 
@@ -72,13 +75,18 @@ public class VocabularyResourceV2 {
         this.vocabularyService = vocabularyService;
     }
 
+    /*
+     * Search Endpoints
+     */
+
     /**
      * {@code GET  /search} : This vocabulary search API is used for the front-end of CVS publication page.
      * It is hidden from swagger since, the parameters filter "f" used in the API are complex.
      *
 
      * @param q the query term.
-     * @param pageable the pagination information.
+     * @param f the filter.
+     * @param pageable pagination information.
 
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of vocabularies in body.
      */
@@ -89,8 +97,6 @@ public class VocabularyResourceV2 {
         @ApiParam( value = "the filter, e.g agency:DDI Alliance;language:en" ) @RequestParam(name = "f", required = false) String f,
         Pageable pageable) {
         log.debug("REST request search vocabulary by query");
-        if (q == null)
-            q = "";
         EsQueryResultDetail esq = VocabularyUtils.prepareEsQuerySearching(q, f, pageable, SearchScope.PUBLICATIONSEARCH);
         vocabularyService.search(esq);
         Page<VocabularyDTO> vocabulariesPage = esq.getVocabularies();
@@ -105,7 +111,7 @@ public class VocabularyResourceV2 {
      * @param query the query term.
      * @param agency the agency.
      * @param lang the language.
-     * @param pageable
+     * @param pageable pagination information.
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of vocabularies in body.
      */
     @GetMapping(
@@ -116,20 +122,14 @@ public class VocabularyResourceV2 {
         notes = "This method searches the vocabulary with the default size of 20")
     public ResponseEntity<CvResult> searchVocabulariesJson(
         @ApiParam(
-            name = "query",
-            type = "String",
             value = "The search term",
             example = "Economics"
         ) @RequestParam (required = false) String query,
         @ApiParam(
-            name = "agency",
-            type = "String",
             value = "The agency",
             example = "CESSDA"
         ) @RequestParam (required = false) String agency,
         @ApiParam(
-            name = "lang",
-            type = "String",
             value = "The language",
             example = "en"
         ) @RequestParam (required = false) String lang,
@@ -171,31 +171,25 @@ public class VocabularyResourceV2 {
      * @param query the query term.
      * @param agency the agency.
      * @param lang the language.
-     * @param pageable
+     * @param pageable pagination information.
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the list of vocabularies in body.
      */
     @GetMapping(
         value="/search/vocabularies",
-        produces = JSONLD_TYPE)
+        produces = MEDIATYPE_JSONLD_VALUE)
     @ApiOperation(
         value = "Search vocabularies",
         notes = "This method searches the vocabulary with the default size of 20")
     public ResponseEntity<List<Object>> searchVocabulariesJsonLd(
         @ApiParam(
-            name = "query",
-            type = "String",
             value = "The search term",
             example = "Economics"
-        ) @RequestParam (required = false) String query,
+        ) @RequestParam(required = false) String query,
         @ApiParam(
-            name = "agency",
-            type = "String",
             value = "The agency",
             example = "CESSDA"
         ) @RequestParam (required = false) String agency,
         @ApiParam(
-            name = "lang",
-            type = "String",
             value = "The language",
             example = "en"
         ) @RequestParam (required = false) String lang,
@@ -223,24 +217,20 @@ public class VocabularyResourceV2 {
      */
     @GetMapping(
         value="/search/codes",
-        produces = JSONLD_TYPE
+        produces = MEDIATYPE_JSONLD_VALUE
     )
-    @ApiOperation( value = "Searching the vocabularies codes that produces JSON-LD based on Skosmos format" )
+    @ApiOperation( value = "Search vocabulary codes, produces JSON-LD based on the Skosmos format" )
     public Map<String, Object> getAllVocabulariesCode(
         @ApiParam(
-            value = "The query, e.g. Economics or with wildcard eco*",
+            value = "The query, supports wildcards (e.g. eco*)",
             example = "Economics",
             required = true
         ) @RequestParam ( name = "query") String query,
         @ApiParam(
-            name = "agency",
-            type = "String",
             value = "The agency",
             example = "CESSDA"
         ) @RequestParam (required = false, name = "agency") String agency,
         @ApiParam(
-            name = "vocab",
-            type = "String",
             value = "The vocabulary",
             example = "TopicClassification",
             required = true
@@ -251,9 +241,10 @@ public class VocabularyResourceV2 {
             required = true
         ) @RequestParam(name = "lang") String lang,
         @ApiParam(
-            value = "The maximum size of codes returned, default 20 maximum 100",
+            value = "Amount of codes to return, maximum 100",
+            allowableValues = "range[1,100]",
             example = "20"
-        ) @RequestParam( required = false, name = "size" ) Integer size
+        ) @RequestParam( defaultValue = "20", name = "size" ) @Max( value = 100 ) int size
     ) {
         log.debug("REST request to get a page of Vocabularies");
         String filter = "language:" + lang + ";vocab:" + vocab ;
@@ -264,7 +255,7 @@ public class VocabularyResourceV2 {
         }
 
         EsQueryResultDetail esq = VocabularyUtils.prepareEsQuerySearching(query, filter, null, SearchScope.PUBLICATIONSEARCH);
-        esq.setCodeSize( size == null ? 20 : size );
+        esq.setCodeSize( size );
         vocabularyService.searchCode(esq);
         Page<VocabularyDTO> vocabulariesPage = esq.getVocabularies();
 
@@ -281,21 +272,36 @@ public class VocabularyResourceV2 {
         }
     }
 
+    /*
+     * Vocabularies Endpoints
+     */
+
     /**
      * {@code GET  /vocabularies/:vocabulary/:versionNumberSl} : Get Vocabulary
      *
-     * @param request
-     * @param vocabulary
-     * @param versionNumberSl
-     * @param languageVersion
+     * @param request the request.
+     * @param vocabulary the vocabulary.
+     * @param versionNumberSl the version number of the source language.
+     * @param languageVersion included language versions, e.g. en-4.0_de-4.0.1, separated by _
      * @return Vocabulary in HTML format
      */
     @GetMapping(
         value="/vocabularies/{vocabulary}/{versionNumberSl}",
-        produces = MediaType.TEXT_HTML_VALUE
+        produces = {
+            MediaType.APPLICATION_JSON_VALUE,
+            MEDIATYPE_JSONLD_VALUE,
+            MediaType.TEXT_HTML_VALUE,
+            MediaType.APPLICATION_PDF_VALUE,
+            ExportService.MEDIATYPE_WORD_VALUE,
+            ExportService.MEDIATYPE_RDF_VALUE
+        }
     )
-    @ApiOperation( value = "Get a Vocabulary in HTML file" )
-    public ResponseEntity<Resource> getVocabularyHtml(
+    @ApiOperation( value = "Get a Vocabulary", response = VocabularyDTO.class )
+    @ApiResponses( {
+        @ApiResponse( code = 200, message = "The vocabulary" ),
+        @ApiResponse( code = 404, message = "Vocabulary not found")
+    } )
+    public ResponseEntity<Object> getVocabulary(
         HttpServletRequest request,
         @ApiParam(
             name = "vocabulary",
@@ -317,6 +323,48 @@ public class VocabularyResourceV2 {
             value = "included language version, e.g. en-4.0_de-4.0.1, separated by _" ,
             example = "en-4.0"
         ) @RequestParam( required = false )  String languageVersion
+    )
+    {
+        var accept = request.getHeader( "Accept" );
+        var mediaType = MediaType.parseMediaType( accept );
+
+        // Switch based on compatible media type - default to application/json if unspecified
+        if (mediaType.isCompatibleWith( MediaType.APPLICATION_JSON ))
+        {
+            var vocabularyDTO = getVocabularyJson( vocabulary, versionNumberSl, languageVersion );
+            return ResponseEntity.ok( vocabularyDTO );
+        }
+        if (mediaType.isCompatibleWith( MEDIATYPE_JSONLD ))
+        {
+            var jsonLd = getVocabularyJsonLd( vocabulary, versionNumberSl, languageVersion );
+            return ResponseEntity.ok( jsonLd );
+        }
+        else if (mediaType.isCompatibleWith( MediaType.APPLICATION_PDF )
+            || mediaType.isCompatibleWith( ExportService.MEDIATYPE_WORD )
+            || mediaType.isCompatibleWith( ExportService.MEDIATYPE_RDF ))
+        {
+            return getVocabularyExport( request, vocabulary, versionNumberSl, languageVersion );
+        }
+        else if (mediaType.isCompatibleWith( MediaType.TEXT_HTML ))
+        {
+            return getVocabularyHtml( request, vocabulary, versionNumberSl, languageVersion );
+        }
+
+        return ResponseEntity.badRequest().build();
+    }
+
+
+    /**
+     * {@code GET  /vocabularies/:vocabulary/:versionNumberSl} : Get Vocabulary
+     *
+     * @param request         the request.
+     * @param vocabulary      the vocabulary.
+     * @param versionNumberSl the version number of the source language.
+     * @param languageVersion included language versions, e.g. en-4.0_de-4.0.1, separated by _
+     * @return Vocabulary in HTML format
+     */
+    public ResponseEntity<Object> getVocabularyHtml(
+        HttpServletRequest request, String vocabulary, String versionNumberSl, String languageVersion
     ) {
         log.debug("REST request to get a HTML file of vocabulary {} with version {} with included versions {}", vocabulary, versionNumberSl, languageVersion);
 
@@ -332,40 +380,12 @@ public class VocabularyResourceV2 {
     /**
      * {@code GET  /vocabularies/:vocabulary/:versionNumberSl} : Get Vocabulary
      *
-     * @param request
-     * @param vocabulary
-     * @param versionNumberSl
-     * @param languageVersion
-     * @return Vocabulary in JSON format
+     * @param vocabulary the vocabulary.
+     * @param versionNumberSl the version number of the source language.
+     * @param languageVersion included language versions, e.g. en-4.0_de-4.0.1, separated by _.
+     * @return Vocabulary
      */
-    @GetMapping(
-        value="/vocabularies/{vocabulary}/{versionNumberSl}",
-        produces = MediaType.APPLICATION_JSON_VALUE
-    )
-    @ApiOperation( value = "Get a Vocabulary in JSON format" )
-    public VocabularyDTO getVocabularyJson(
-        HttpServletRequest request,
-        @ApiParam(
-            name = "vocabulary",
-            type = "String",
-            value = "The vocabulary",
-            example = "TopicClassification",
-            required = true
-        ) @PathVariable String vocabulary,
-        @ApiParam(
-            name = "versionNumberSl",
-            type = "String",
-            value = "The version number of Source language",
-            example = "4.0",
-            required = true
-        ) @PathVariable String versionNumberSl,
-        @ApiParam(
-            name = "languageVersion",
-            type = "String",
-            value = "included language version, e.g. en-4.0_de-4.0.1, separated by _" ,
-            example = "en-4.0"
-        ) @RequestParam( required = false )  String languageVersion
-    ) {
+    public VocabularyDTO getVocabularyJson( String vocabulary, String versionNumberSl, String languageVersion ) {
         log.debug(VERSION_WITH_INCLUDED_VERSIONS, vocabulary, versionNumberSl, languageVersion);
         VocabularyDTO vocabularyDTO = getVocabularyDTOAndFilterVersions(vocabulary, versionNumberSl, languageVersion);
         if (vocabularyDTO.getVersions().isEmpty()) {
@@ -376,91 +396,14 @@ public class VocabularyResourceV2 {
     }
 
     /**
-     * {@code GET  /vocabularies/:vocabulary/:versionNumberSl/:language} : Get Vocabulary
-     *
-     * @param request
-     * @param vocabulary
-     * @param versionNumber
-     * @param language
-     * @return Vocabulary in JSON format
-     */
-    @GetMapping(
-        value="/codes/{vocabulary}/{versionNumber}/{language}",
-        produces = MediaType.APPLICATION_JSON_VALUE
-    )
-    @ApiOperation( value = "Get a Code in JSON format" )
-    public Set<ConceptDTO> getCodeJson(
-        HttpServletRequest request,
-        @ApiParam(
-            name = "vocabulary",
-            type = "String",
-            value = "The vocabulary",
-            example = "TopicClassification",
-            required = true
-        ) @PathVariable String vocabulary,
-        @ApiParam(
-            name = "versionNumber",
-            type = "String",
-            value = "The version number",
-            example = "4.0",
-            required = true
-        ) @PathVariable String versionNumber,
-        @ApiParam(
-            name = "language",
-            type = "String",
-            value = "The language" ,
-            example = "en",
-            required = true
-        ) @PathVariable( required = false )  String language
-    ) {
-        final String langVersion = language + "-" + versionNumber;
-        log.debug(VERSION_WITH_INCLUDED_VERSIONS, vocabulary, VersionUtils.getSlVersionNumber(versionNumber), langVersion );
-        final VocabularyDTO vocabularyDTO = getVocabularyDTOAndFilterVersions(vocabulary, VersionUtils.getSlVersionNumber(versionNumber).toString(), language + "-" + versionNumber);
-        var versionsIterator = vocabularyDTO.getVersions().iterator();
-        if (versionsIterator.hasNext()) {
-            return versionsIterator.next().getConcepts();
-        } else {
-            return Collections.emptySet();
-        }
-    }
-
-    /**
      * {@code GET  /vocabularies/:vocabulary/:versionNumberSl} : Get Vocabulary
      *
-     * @param request
-     * @param vocabulary
-     * @param versionNumberSl
-     * @param languageVersion
+     * @param vocabulary the vocabulary.
+     * @param versionNumberSl the version number of the source language.
+     * @param languageVersion included language versions, e.g. en-4.0_de-4.0.1, separated by _
      * @return Vocabulary in JSON-LD format
      */
-    @GetMapping(
-        value="/vocabularies/{vocabulary}/{versionNumberSl}",
-        produces = JSONLD_TYPE
-    )
-    @ApiOperation( value = "Get a Vocabulary in JSON-LD format" )
-    public List<Map<String, Object>> getVocabularyJsonLd(
-        HttpServletRequest request,
-        @ApiParam(
-            name = "vocabulary",
-            type = "String",
-            value = "The vocabulary",
-            example = "TopicClassification",
-            required = true
-        ) @PathVariable String vocabulary,
-        @ApiParam(
-            name = "versionNumberSl",
-            type = "String",
-            value = "The version number of Source language",
-            example = "4.0",
-            required = true
-        ) @PathVariable String versionNumberSl,
-        @ApiParam(
-            name = "languageVersion",
-            type = "String",
-            value = "included language version, e.g. en-4.0_de-4.0.1, separated by _" ,
-            example = "en-4.0"
-        ) @RequestParam( required = false )  String languageVersion
-    ) {
+    public List<Map<String, Object>> getVocabularyJsonLd( String vocabulary, String versionNumberSl, String languageVersion ) {
         log.debug(VERSION_WITH_INCLUDED_VERSIONS, vocabulary, versionNumberSl, languageVersion);
         VocabularyDTO vocabularyDTO = getVocabularyDTOAndFilterVersions( vocabulary, versionNumberSl, languageVersion );
 
@@ -473,39 +416,14 @@ public class VocabularyResourceV2 {
     /**
      * {@code GET  /vocabularies/:vocabulary/:versionNumberSl} : Get Vocabulary
      *
-     * @param request
-     * @param vocabulary
-     * @param versionNumberSl
-     * @param languageVersion
+     * @param request         the request.
+     * @param vocabulary      the vocabulary.
+     * @param versionNumberSl the version number of the source language.
+     * @param languageVersion included language versions, e.g. en-4.0_de-4.0.1, separated by _
      * @return Vocabulary
      */
-    @GetMapping(
-        value="/vocabularies/{vocabulary}/{versionNumberSl}",
-        produces = { MediaType.APPLICATION_PDF_VALUE, ExportService.MEDIATYPE_WORD_VALUE, ExportService.MEDIATYPE_RDF_VALUE }
-    )
-    @ApiOperation( value = "Get a Vocabulary in PDF file" )
-    public ResponseEntity<Resource> getVocabularyPdf(
-        HttpServletRequest request,
-        @ApiParam(
-            name = "vocabulary",
-            type = "String",
-            value = "The vocabulary",
-            example = "TopicClassification",
-            required = true
-        ) @PathVariable String vocabulary,
-        @ApiParam(
-            name = "versionNumberSl",
-            type = "String",
-            value = "The version number of Source language",
-            example = "4.0",
-            required = true
-        ) @PathVariable String versionNumberSl,
-        @ApiParam(
-            name = "languageVersion",
-            type = "String",
-            value = "included language version, e.g. en-4.0_de-4.0.1, separated by _" ,
-            example = "en-4.0"
-        ) @RequestParam( required = false )  String languageVersion
+    public ResponseEntity<Object> getVocabularyExport(
+        HttpServletRequest request, String vocabulary, String versionNumberSl, String languageVersion
     ) {
         log.debug("REST request to get a PDF file of vocabulary {} with version {} with included versions {}", vocabulary, versionNumberSl, languageVersion);
 
@@ -520,6 +438,55 @@ public class VocabularyResourceV2 {
             .header(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT_FILENAME + fileName.getFileName())
             .body(new FileSystemResource( fileName ) );
     }
+
+    /*
+     * Code Endpoint
+     */
+
+    /**
+     * {@code GET  /vocabularies/:vocabulary/:versionNumberSl/:language} : Get Vocabulary
+     *
+     * @param vocabulary the vocabulary.
+     * @param versionNumber the version number.
+     * @param language the language.
+     * @return Set of codes.
+     */
+    @GetMapping(
+        value="/codes/{vocabulary}/{versionNumber}/{language}",
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @ApiOperation( value = "Get a Code" )
+    public Set<ConceptDTO> getCodeJson(
+        @ApiParam(
+            value = "The vocabulary",
+            example = "TopicClassification",
+            required = true
+        ) @PathVariable String vocabulary,
+        @ApiParam(
+            value = "The version number",
+            example = "4.0",
+            required = true
+        ) @PathVariable String versionNumber,
+        @ApiParam(
+            value = "The language" ,
+            example = "en",
+            required = true
+        ) @PathVariable String language
+    ) {
+        final String langVersion = language + "-" + versionNumber;
+        log.debug(VERSION_WITH_INCLUDED_VERSIONS, vocabulary, VersionUtils.getSlVersionNumber(versionNumber), langVersion );
+        final VocabularyDTO vocabularyDTO = getVocabularyDTOAndFilterVersions(vocabulary, VersionUtils.getSlVersionNumber(versionNumber).toString(), langVersion);
+        var versionsIterator = vocabularyDTO.getVersions().iterator();
+        if (versionsIterator.hasNext()) {
+            return versionsIterator.next().getConcepts();
+        } else {
+            return Collections.emptySet();
+        }
+    }
+
+    /*
+     * Compare Vocabulary Endpoint
+     */
 
     /**
      * {@code GET  /editors/vocabularies/compare-prev/:id} : get the text to be compared by diff-algorithm,
@@ -562,44 +529,44 @@ public class VocabularyResourceV2 {
     value="/vocabularies-published",
     produces = MediaType.APPLICATION_JSON_VALUE
     )
-    @ApiOperation( value = "Get list of the agencies and the published controlled vocabularies with the details of the rest API link. The rest API links need a specific content type e.g. JSON, PDF" )
-    public Map<String, Map<String, Map<String, Map<String, String>>>> getAllVocabularies(HttpServletRequest request)
+    @ApiOperation( value = "Get a map of all agencies with links to their published controlled vocabularies",
+        notes = "The controlled vocabulary links are relative links and must be resolved from the base URL of the server.")
+    public Map<String, Map<String, Map<String, Map<VersionNumber, URI>>>> getAllVocabularies(HttpServletRequest request) throws URISyntaxException
     {
         log.debug( "REST: Getting all Vocabularies" );
-        Map<String, Map<String, Map<String, Map<String, String>>>> agencyCvMap = new TreeMap<>();
-        List<VocabularyDTO> vocabularies = vocabularyService.findAll();
-        vocabularies = vocabularies.stream().sorted( Comparator.comparing( VocabularyDTO::getNotation ) ).collect( Collectors.toList() );
+        var agencyCvMap = new TreeMap<String, Map<String, Map<String, Map<VersionNumber, URI>>>>();
+
+        // Get all vocabularies that are not withdrawn, sorted by notation
+        var vocabularies = vocabularyService.findAll().stream()
+            .filter( voc -> Boolean.TRUE.equals( voc.isWithdrawn() ) )
+            .sorted( Comparator.comparing( VocabularyDTO::getNotation ) )
+            .collect( Collectors.toList() );
+
         for ( VocabularyDTO voc : vocabularies )
         {
-            // ignore withdrawn vocabularies
-            if ( Boolean.TRUE.equals( voc.isWithdrawn() ) )
-            {
-                continue;
-            }
-
             // check if there is published version
             if ( voc.getVersions().stream().anyMatch( v -> v.getStatus() == Status.PUBLISHED ) )
             {
-                Map<String, Map<String, Map<String, String>>> vocabMap = agencyCvMap.computeIfAbsent( voc.getAgencyName(), k -> new LinkedHashMap<>() );
+                var vocabMap = agencyCvMap.computeIfAbsent( voc.getAgencyName(), k -> new LinkedHashMap<>() );
                 List<VersionDTO> versions = new ArrayList<>( voc.getVersions() );
                 versions.sort( Comparator.comparing( VersionDTO::getNumber ) );
                 for ( VersionDTO version : versions )
                 {
-                    Map<String, Map<String, String>> langMap = vocabMap.computeIfAbsent( version.getNotation(), k -> new LinkedHashMap<>() );
-                    Map<String, String> versionMap = langMap.computeIfAbsent(
+                    var langMap = vocabMap.computeIfAbsent( version.getNotation(), k -> new LinkedHashMap<>() );
+                    var versionMap = langMap.computeIfAbsent(
                         version.getLanguage() + "(" + version.getItemType() + ")", k -> new LinkedHashMap<>() );
-                    versionMap.put( version.getNumber().toString(),
-                        request.getContextPath() + "/" + "v2/vocabularies/" + version.getNotation() + "/" +
-                            version.getNumber().getBasePatchVersion() + "?languageVersion=" +
-                            version.getLanguage() +
-                            "-" + version.getNumber() );
-                    for ( Map<String, Object> versionHistory : version.getVersionHistories() )
+                    var uriString = request.getContextPath() +
+                        "/v2/vocabularies/" + version.getNotation() +
+                        "/" + version.getNumber().getBasePatchVersion()
+                        + "?languageVersion=" + version.getLanguage() + "-" + version.getNumber();
+                    versionMap.put( version.getNumber(), new URI( uriString ) );
+                    for ( VersionHistoryDTO versionHistory : version.getVersionHistories() )
                     {
-                        versionMap.put( versionHistory.get( VERSION ).toString(),
-                            request.getContextPath() + "/" + "v2/vocabularies/" + version.getNotation() + "/" +
-                                VersionUtils.getSlVersionNumber( versionHistory.get( VERSION ).toString() ) +
-                                "?languageVersion=" + version.getLanguage() + "-" +
-                                versionHistory.get( VERSION ).toString() );
+                        var versionHistoryUriString = request.getContextPath() +
+                            "/v2/vocabularies/" + version.getNotation() +
+                            "/" + versionHistory.getVersion().getBasePatchVersion() +
+                            "?languageVersion=" + version.getLanguage() + "-" + versionHistory.getVersion();
+                        versionMap.put( versionHistory.getVersion(), new URI( versionHistoryUriString ) );
                     }
                 }
             }

--- a/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/VocabularyResourceV2.java
@@ -23,6 +23,7 @@ import eu.cessda.cvs.service.VocabularyService;
 import eu.cessda.cvs.service.dto.*;
 import eu.cessda.cvs.service.search.EsQueryResultDetail;
 import eu.cessda.cvs.service.search.SearchScope;
+import eu.cessda.cvs.utils.LanguageVersion;
 import eu.cessda.cvs.utils.VersionNumber;
 import eu.cessda.cvs.utils.VersionUtils;
 import eu.cessda.cvs.utils.VocabularyUtils;
@@ -326,7 +327,15 @@ public class VocabularyResourceV2 {
     )
     {
         var accept = request.getHeader( "Accept" );
-        var mediaType = MediaType.parseMediaType( accept );
+        MediaType mediaType;
+        if (accept != null)
+        {
+            mediaType = MediaType.parseMediaType( accept );
+        }
+        else
+        {
+            mediaType = MediaType.ALL;
+        }
 
         // Switch based on compatible media type - default to application/json if unspecified
         if (mediaType.isCompatibleWith( MediaType.APPLICATION_JSON ))
@@ -334,7 +343,7 @@ public class VocabularyResourceV2 {
             var vocabularyDTO = getVocabularyJson( vocabulary, versionNumberSl, languageVersion );
             return ResponseEntity.ok( vocabularyDTO );
         }
-        if (mediaType.isCompatibleWith( MEDIATYPE_JSONLD ))
+        else if (mediaType.isCompatibleWith( MEDIATYPE_JSONLD ))
         {
             var jsonLd = getVocabularyJsonLd( vocabulary, versionNumberSl, languageVersion );
             return ResponseEntity.ok( jsonLd );
@@ -504,11 +513,14 @@ public class VocabularyResourceV2 {
         @ApiParam( value = "the second version e.g en-1.0" )@PathVariable String lv2
     ) {
         log.debug("REST request to get Vocabulary comparison text from JSON files of CV {}, between version {} and {}", cv, lv1, lv2);
-        final String[] splitLanguageVersion1 = VersionUtils.splitLanguageVersion(lv1);
-        final String[] splitLanguageVersion2 = VersionUtils.splitLanguageVersion(lv2);
+        LanguageVersion splitLanguageVersion1 = VersionUtils.splitLanguageVersion(lv1);
+        LanguageVersion splitLanguageVersion2 = VersionUtils.splitLanguageVersion(lv2);
 
-        VersionDTO version1 = VocabularyUtils.getVersionByLangVersion(vocabularyService.getVocabularyByNotationAndVersion(cv, splitLanguageVersion1[0], false), splitLanguageVersion1[2], splitLanguageVersion1[1]);
-        VersionDTO version2 = VocabularyUtils.getVersionByLangVersion(vocabularyService.getVocabularyByNotationAndVersion(cv, splitLanguageVersion2[0], false), splitLanguageVersion2[2], splitLanguageVersion2[1]);
+        VocabularyDTO vocabulary1 = vocabularyService.getVocabularyByNotationAndVersion( cv, splitLanguageVersion1.getVersionNumber().getBasePatchVersion().toString(), false );
+        VocabularyDTO vocabulary2 = vocabularyService.getVocabularyByNotationAndVersion( cv, splitLanguageVersion2.getVersionNumber().getBasePatchVersion().toString(), false );
+
+        VersionDTO version1 = VocabularyUtils.getVersionByLangVersion( vocabulary1, splitLanguageVersion1.getLanguage(), splitLanguageVersion1.getVersionNumber() );
+        VersionDTO version2 = VocabularyUtils.getVersionByLangVersion( vocabulary2, splitLanguageVersion2.getLanguage(), splitLanguageVersion2.getVersionNumber());
 
         return ResourceUtils.getListResponseEntity(version1, version2);
     }

--- a/src/main/java/eu/cessda/cvs/web/rest/domain/Maintenance.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/domain/Maintenance.java
@@ -16,21 +16,18 @@
 package eu.cessda.cvs.web.rest.domain;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 public class Maintenance implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
-    private String output;
-    private LocalDateTime timestamp;
-    private String type;
+    private final String output;
+    private final OffsetDateTime timestamp;
+    private final Operation type;
 
-    public Maintenance() {
-    }
-
-    public Maintenance(String output, String type) {
+    public Maintenance(String output, Operation type) {
         this.output = output;
-        this.timestamp = LocalDateTime.now();
+        this.timestamp = OffsetDateTime.now();
         this.type = type;
     }
 
@@ -38,23 +35,15 @@ public class Maintenance implements Serializable {
         return output;
     }
 
-    public void setOutput(String output) {
-        this.output = output;
-    }
-
-    public LocalDateTime getTimestamp() {
+    public OffsetDateTime getTimestamp() {
         return timestamp;
     }
 
-    public void setTimestamp(LocalDateTime timestamp) {
-        this.timestamp = timestamp;
-    }
-
-    public String getType() {
+    public Operation getType() {
         return type;
     }
 
-    public void setType(String type) {
-        this.type = type;
+    public enum Operation {
+        GENERATE_JSON, INDEX_AGENCY, INDEX_AGENCY_STAT, INDEX_VOCABULARY_PUBLISH, INDEX_VOCABULARY_EDITOR
     }
 }

--- a/src/main/java/eu/cessda/cvs/web/rest/errors/ExceptionTranslator.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/errors/ExceptionTranslator.java
@@ -37,7 +37,6 @@ import org.zalando.problem.spring.web.advice.ProblemHandling;
 import org.zalando.problem.spring.web.advice.security.SecurityAdviceTrait;
 import org.zalando.problem.violations.ConstraintViolationProblem;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.servlet.http.HttpServletRequest;
@@ -115,7 +114,7 @@ public class ExceptionTranslator implements ProblemHandling, SecurityAdviceTrait
     }
 
     @Override
-    public ResponseEntity<Problem> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, @Nonnull NativeWebRequest request) {
+    public ResponseEntity<Problem> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, NativeWebRequest request) {
         BindingResult result = ex.getBindingResult();
         List<FieldErrorVM> fieldErrors = result.getFieldErrors().stream()
             .map(f -> new FieldErrorVM(f.getObjectName().replaceFirst("DTO$", ""), f.getField(), f.getCode()))

--- a/src/main/java/eu/cessda/cvs/web/rest/utils/ResourceUtils.java
+++ b/src/main/java/eu/cessda/cvs/web/rest/utils/ResourceUtils.java
@@ -24,12 +24,16 @@ import eu.cessda.cvs.utils.VersionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.*;
 
 public class ResourceUtils {
+    public static final String MEDIATYPE_JSONLD_VALUE = "application/ld+json";
+    public static final MediaType MEDIATYPE_JSONLD = MediaType.parseMediaType( MEDIATYPE_JSONLD_VALUE );
+
     public static final String LANGUAGE = "@language";
     public static final String VALUE = "@value";
     public static final String ID = "@id";
@@ -37,11 +41,11 @@ public class ResourceUtils {
 
     private ResourceUtils(){}
 
-    public static ResponseEntity<List<String>> getListResponseEntity(VersionDTO version1, VersionDTO version2) {
-        List<String> compareVersions = VersionUtils.compareCurPrevCV(version1, version2);
+    public static ResponseEntity<List<String>> getListResponseEntity(VersionDTO currentVersion, VersionDTO previousVersion) {
+        List<String> compareVersions = VersionUtils.compareCurPrevCV(currentVersion, previousVersion);
         HttpHeaders headers = new HttpHeaders();
-        headers.add("X-Prev-Cv-Version", version2.getNotation() + " " +version2.getItemType() + " v." + version2.getNumber());
-        headers.add("X-Current-Cv-Version", version1.getNotation() + " " +version1.getItemType() + " v." + version1.getNumber());
+        headers.add("X-Prev-Cv-Version", previousVersion.getNotation() + " " + previousVersion.getItemType() + " v." + previousVersion.getNumber());
+        headers.add("X-Current-Cv-Version", currentVersion.getNotation() + " " + currentVersion.getItemType() + " v." + currentVersion.getNumber());
         return ResponseEntity.ok().headers(headers).body(compareVersions);
     }
 

--- a/src/main/webapp/app/account/password/password-strength-bar.component.ts
+++ b/src/main/webapp/app/account/password/password-strength-bar.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, ElementRef, Input, Renderer2, inject } from '@angular/core';
+import { Component, ElementRef, inject, Input, Renderer2 } from '@angular/core';
 
 @Component({
   selector: 'jhi-password-strength-bar',
@@ -48,7 +48,7 @@ export class PasswordStrengthBarComponent {
 
     const flags = [lowerLetters, upperLetters, numbers, symbols];
     const passedMatches = flags.filter((isMatchedFlag: boolean) => {
-      return isMatchedFlag === true;
+      return isMatchedFlag;
     }).length;
 
     force += 2 * p.length + (p.length >= 10 ? 1 : 0);
@@ -66,7 +66,7 @@ export class PasswordStrengthBarComponent {
   }
 
   getColor(s: number): { idx: number; color: string } {
-    let idx = 0;
+    let idx;
     if (s <= 10) {
       idx = 0;
     } else if (s <= 20) {

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injectable, inject } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import { JhiLanguageService } from 'ng-jhipster';
@@ -70,12 +70,12 @@ export class AccountService {
   /**
    * Check if user has authority to access certain DOM
    * @param actionType
-   * @param agencyId, the agency ID, ID = 0 means that any agency
+   * @param agencyId the agency ID, ID = 0 means that any agency
    * @param agencyRoles
    * @param language
    */
   hasAnyAgencyAuthority(actionType: string, agencyId: number, agencyRoles: string[], language?: string): boolean {
-    if (!this.userIdentity || !this.userIdentity.authorities) {
+    if (!this.userIdentity?.authorities) {
       return false;
     }
     // check if admin
@@ -83,7 +83,7 @@ export class AccountService {
       return true;
     }
 
-    // check by actionType, agencyId, agencyRoles, languages, aginst user.userAgency
+    // check by actionType, agencyId, agencyRoles, languages, against user.userAgency
     switch (actionType) {
       case 'CREATE_CV':
       case 'EDIT_CV':

--- a/src/main/webapp/app/editor/editor-detail-code-csv-import-dialog.component.ts
+++ b/src/main/webapp/app/editor/editor-detail-code-csv-import-dialog.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, ElementRef, ViewChild, inject } from '@angular/core';
+import { Component, ElementRef, inject, ViewChild } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { EditorService } from 'app/editor/editor.service';
 import { Version } from 'app/shared/model/version.model';
@@ -215,7 +215,7 @@ export class EditorDetailCodeCsvImportDialogComponent {
     this.resetConceptsAndCodeSnippets();
 
     for (let i = 0; i < this.csvContents.length; i++) {
-      if (this.markedRows[i] === false) {
+      if (!this.markedRows[i]) {
         continue;
       }
       // check for existing concepts, overwrite if exist
@@ -242,11 +242,11 @@ export class EditorDetailCodeCsvImportDialogComponent {
           // calculate conceptPosition as last child of parent
           const conceptChildren = this.concepts.filter(c => c.parent === parentConcept.notation);
           if (conceptChildren.length === 0) {
-            conceptPosition = parentConcept.position || 0 + 1;
+            conceptPosition = parentConcept.position || 1;
           } else {
-            conceptPosition = this.findLastChildForPosition(parentConcept).position || 0 + 1;
+            conceptPosition = this.findLastChildForPosition(parentConcept).position || 1;
             // check for equal or larger position if exist and increment to normalize
-            this.concepts.filter(c => c.position || 0 >= conceptPosition).forEach(c => (c.position = c.position || 0 + 1));
+            this.concepts.filter(c => c.position || 0 >= conceptPosition).forEach(c => (c.position = c.position || 1));
           }
         }
         const newConcept: Concept = {

--- a/src/main/webapp/app/editor/editor-detail-cv-forward-status-dialog.component.ts
+++ b/src/main/webapp/app/editor/editor-detail-cv-forward-status-dialog.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
@@ -242,7 +242,7 @@ export class EditorDetailCvForwardStatusDialogComponent implements OnInit {
           VocabularyUtil.getSlMajorMinorVersionNumber(this.slVersionNumber) + '.' + this.proposedPatchNumber;
         this.versionParam.concepts.forEach(c => {
           if (!c.deprecated) {
-            if (!c.title || c.title === null || c.title === '') {
+            if (!c.title || c.title === '') {
               this.missingTranslations.push(c.notation);
             }
           }

--- a/src/main/webapp/app/editor/editor-detail.component.ts
+++ b/src/main/webapp/app/editor/editor-detail.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, ElementRef, NgZone, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { Component, ElementRef, inject, NgZone, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { JhiDataUtils, JhiEventManager, JhiEventWithContent } from 'ng-jhipster';
 
@@ -23,7 +23,7 @@ import { Version } from 'app/shared/model/version.model';
 import VocabularyUtil from 'app/shared/util/vocabulary-util';
 import { FormBuilder, FormControl, Validators } from '@angular/forms';
 import { EditorService } from 'app/editor/editor.service';
-import { RouteEventsService } from 'app/shared';
+import { RouteEventsService, VocabularyLanguageFromKeyPipe } from 'app/shared';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { EditorDetailCvAddEditDialogComponent } from 'app/editor/editor-detail-cv-add-edit-dialog.component';
 import { EditorDetailCvCommentDialogComponent } from 'app/editor/editor-detail-cv-comment-dialog.component';
@@ -43,7 +43,6 @@ import moment from 'moment';
 import { AccountService } from 'app/core/auth/account.service';
 import { Account } from 'app/core/user/account.model';
 import { AppScope } from 'app/shared/model/enumerations/app-scope.model';
-import { VocabularyLanguageFromKeyPipe } from 'app/shared';
 import Quill from 'quill';
 import { QuillModules } from 'ngx-quill';
 import { AgencyRole } from 'app/shared/model/enumerations/agency-role.model';
@@ -269,11 +268,7 @@ export class EditorDetailComponent implements OnInit, OnDestroy {
         }
       }
     } else {
-      if (this.version.status === 'READY_TO_TRANSLATE' || this.version.status === 'PUBLISHED') {
-        this.enableAddTl = true;
-      } else {
-        this.enableAddTl = false;
-      }
+      this.enableAddTl = this.version.status === 'READY_TO_TRANSLATE' || this.version.status === 'PUBLISHED';
       // check all versions if there is any READY_TO_PUBLISH state for TL
       for (const vocab of this.vocabulary?.versions || []) {
         if (vocab.status === 'READY_TO_PUBLISH') {

--- a/src/main/webapp/app/editor/editor.service.ts
+++ b/src/main/webapp/app/editor/editor.service.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injectable, inject } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
@@ -101,12 +101,11 @@ export class EditorService {
   }
 
   protected convertDateFromClient(vocabulary: Vocabulary): Vocabulary {
-    const copy: Vocabulary = Object.assign({}, vocabulary, {
+    return Object.assign({}, vocabulary, {
       publicationDate:
         vocabulary.publicationDate && vocabulary.publicationDate.isValid() ? vocabulary.publicationDate.format(DATE_FORMAT) : undefined,
       lastModified: vocabulary.lastModified && vocabulary.lastModified.isValid() ? vocabulary.lastModified.toJSON() : undefined,
     });
-    return copy;
   }
 
   search(req?: SearchRequest): Observable<HttpResponse<CvResult>> {

--- a/src/main/webapp/app/shared/alert/alert-error.component.ts
+++ b/src/main/webapp/app/shared/alert/alert-error.component.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, OnDestroy, inject } from '@angular/core';
+import { Component, inject, OnDestroy } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { TranslateService } from '@ngx-translate/core';
-import { JhiEventManager, JhiAlert, JhiAlertService, JhiEventWithContent } from 'ng-jhipster';
+import { JhiAlert, JhiAlertService, JhiEventManager, JhiEventWithContent } from 'ng-jhipster';
 import { Subscription } from 'rxjs';
 
 import { AlertError } from './alert-error.model';
@@ -129,7 +129,7 @@ export class AlertErrorComponent implements OnDestroy {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   addErrorAlert(message: string, key?: string, data?: any): void {
-    message = key && key !== null ? key : message;
+    message = key && true ? key : message;
 
     const newAlert: JhiAlert = {
       type: 'danger',

--- a/src/main/webapp/app/shared/util/vocabulary-util.ts
+++ b/src/main/webapp/app/shared/util/vocabulary-util.ts
@@ -382,8 +382,6 @@ export default class VocabularyUtil {
   /**
    * Returns true if there's at least one version among versions which belongs to the bundle. False otherwise.
    *
-   * @param vocab
-   * @param lang
    * @param versions
    * @param bundle
    * @returns

--- a/src/main/webapp/app/shared/vocabulary-download/vocabulary-download.component.ts
+++ b/src/main/webapp/app/shared/vocabulary-download/vocabulary-download.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AfterViewInit, Component, Input, NgZone, OnInit, inject } from '@angular/core';
+import { AfterViewInit, Component, inject, Input, NgZone, OnInit } from '@angular/core';
 import { HomeService } from 'app/home/home.service';
 import { EditorService } from 'app/editor/editor.service';
 import { JhiEventManager } from 'ng-jhipster';
@@ -142,7 +142,7 @@ export class VocabularyDownloadComponent implements OnInit, AfterViewInit {
   getCheckedItems(checkedArray: boolean[]): string {
     let selectedVersion = '';
     for (let i = 0; i < checkedArray.length; i++) {
-      if (checkedArray[i] === true) {
+      if (checkedArray[i]) {
         selectedVersion += this.downloadCheckboxes[i] + '_';
       }
     }
@@ -158,8 +158,7 @@ export class VocabularyDownloadComponent implements OnInit, AfterViewInit {
   }
 
   updateSelection(array: boolean[], i: number, event: Event) {
-    const checked = (event.target as HTMLInputElement).checked;
-    array[i] = checked;
+    array[i] = (event.target as HTMLInputElement).checked;
   }
 
   downloadDocx(): void {

--- a/src/main/webapp/app/shared/vocabulary-search-result/vocabulary-search-result.component.ts
+++ b/src/main/webapp/app/shared/vocabulary-search-result/vocabulary-search-result.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, ElementRef, Input, OnInit, ViewChild, inject } from '@angular/core';
+import { Component, ElementRef, inject, Input, OnInit, ViewChild } from '@angular/core';
 import { EditorService, SearchRequest } from 'app/editor/editor.service';
 import { JhiEventManager, JhiLanguageService } from 'ng-jhipster';
 import { AppScope } from 'app/shared/model/enumerations/app-scope.model';
@@ -202,8 +202,7 @@ export class VocabularySearchResultComponent implements OnInit {
   private filterAdminAgencies(): string {
     this.activeAggAgency = [];
 
-    let adminAgencies: string[] = [];
-    adminAgencies = this.accountService.getUserAgencies();
+    const adminAgencies = this.accountService.getUserAgencies();
     adminAgencies.forEach(agency => {
       this.activeAggAgency.push(agency);
     });

--- a/src/main/webapp/swagger-ui/index.html
+++ b/src/main/webapp/swagger-ui/index.html
@@ -49,7 +49,7 @@
             });
 
             // Build a system
-            var ui = SwaggerUIBundle({
+            window.ui = SwaggerUIBundle({
                 urls: urls,
                 dom_id: '#swagger-ui',
                 deepLinking: true,
@@ -72,8 +72,6 @@
                     return req;
                 }
             });
-
-            window.ui = ui
         });
 
     };

--- a/src/test/java/eu/cessda/cvs/service/dto/CodeDTOTest.java
+++ b/src/test/java/eu/cessda/cvs/service/dto/CodeDTOTest.java
@@ -31,17 +31,17 @@ class CodeDTOTest {
             String uuid1 = UUID.randomUUID().toString();
             String uuid2 = UUID.randomUUID().toString();
 
-            if( lang.equals(Language.UNKNOWN))
-                continue;
-
-            codeDTO.setTitleDefinition(uuid1, uuid2, lang.getIso(), false);
-            assertThat(codeDTO.getTitleByLanguage(lang.getIso())).isEqualTo(uuid1);
-            assertThat(codeDTO.getDefinitionByLanguage(lang.getIso())).isEqualTo(uuid2);
-            codeDTO.setTitleDefinition(uuid1, null, lang.getIso(), true);
-            assertThat(codeDTO.getTitleByLanguage(lang.getIso())).isEqualTo(uuid1);
-            assertThat(codeDTO.getDefinitionByLanguage(lang.getIso())).isEqualTo(uuid2);
+            if ( lang != Language.UNKNOWN )
+            {
+                codeDTO.setTitleDefinition( uuid1, uuid2, lang.getIso(), false );
+                assertThat( codeDTO.getTitleByLanguage( lang.getIso() ) ).isEqualTo( uuid1 );
+                assertThat( codeDTO.getDefinitionByLanguage( lang.getIso() ) ).isEqualTo( uuid2 );
+                codeDTO.setTitleDefinition( uuid1, null, lang.getIso(), true );
+                assertThat( codeDTO.getTitleByLanguage( lang.getIso() ) ).isEqualTo( uuid1 );
+                assertThat( codeDTO.getDefinitionByLanguage( lang.getIso() ) ).isEqualTo( uuid2 );
+            }
         }
-        assertThat(codeDTO.getLanguages().size()).isEqualTo(Language.values().length - 1);
+        assertThat(codeDTO.getLanguages()).hasSize(Language.values().length - 1);
     }
 
     @Test

--- a/src/test/java/eu/cessda/cvs/service/dto/VocabularyDTOTest.java
+++ b/src/test/java/eu/cessda/cvs/service/dto/VocabularyDTOTest.java
@@ -33,22 +33,21 @@ class VocabularyDTOTest {
     void switchGetterAndSetterVocabularyTest(){
         VocabularyDTO vocabularyDTO = new VocabularyDTO();
         for (Language lang : Language.values()) {
-            if (lang.equals(Language.UNKNOWN)) {
-                continue;
+            if ( lang != Language.UNKNOWN )
+            {
+                String uuid1 = UUID.randomUUID().toString();
+                String uuid2 = UUID.randomUUID().toString();
+                String uuid3 = UUID.randomUUID().toString().substring( 0, 5 );
+
+                vocabularyDTO.setTitleDefinition( uuid1, uuid2, lang.getIso(), false );
+                vocabularyDTO.setVersionByLanguage( lang.getIso(), uuid3 );
+                assertThat( vocabularyDTO.getTitleByLanguage( lang.getIso() ) ).isEqualTo( uuid1 );
+                assertThat( vocabularyDTO.getDefinitionByLanguage( lang.getIso() ) ).isEqualTo( uuid2 );
+                assertThat( vocabularyDTO.getVersionByLanguage( lang.getIso() ) ).isEqualTo( uuid3 );
+                vocabularyDTO.setTitleDefinition( uuid1, null, lang.getIso(), true );
+                assertThat( vocabularyDTO.getTitleByLanguage( lang.getIso() ) ).isEqualTo( uuid1 );
+                assertThat( vocabularyDTO.getDefinitionByLanguage( lang.getIso() ) ).isEqualTo( uuid2 );
             }
-
-            String uuid1 = UUID.randomUUID().toString();
-            String uuid2 = UUID.randomUUID().toString();
-            String uuid3 = UUID.randomUUID().toString().substring(0,5);
-
-            vocabularyDTO.setTitleDefinition(uuid1, uuid2, lang.getIso(), false);
-            vocabularyDTO.setVersionByLanguage(lang.getIso(), uuid3);
-            assertThat(vocabularyDTO.getTitleByLanguage(lang.getIso())).isEqualTo(uuid1);
-            assertThat(vocabularyDTO.getDefinitionByLanguage(lang.getIso())).isEqualTo(uuid2);
-            assertThat(vocabularyDTO.getVersionByLanguage(lang.getIso())).isEqualTo(uuid3);
-            vocabularyDTO.setTitleDefinition(uuid1, null, lang.getIso(), true);
-            assertThat(vocabularyDTO.getTitleByLanguage(lang.getIso())).isEqualTo(uuid1);
-            assertThat(vocabularyDTO.getDefinitionByLanguage(lang.getIso())).isEqualTo(uuid2);
         }
     }
 

--- a/src/test/java/eu/cessda/cvs/utils/VersionNumberTest.java
+++ b/src/test/java/eu/cessda/cvs/utils/VersionNumberTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017-2023 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.cessda.cvs.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class VersionNumberTest
+{
+    @Test
+    void createThreePartFromString() {
+        String input = "1.2.3";
+
+        var versionNumber = VersionNumber.fromString( input );
+
+        // Assert all components are as expected
+        assertThat( versionNumber.getMajorNumber() ).isEqualTo( 1 );
+        assertThat( versionNumber.getMinorNumber() ).isEqualTo( 2 );
+        assertThat( versionNumber.getPatchNumber() ).isEqualTo( 3 );
+    }
+
+    @Test
+    void createTwoPartFromString() {
+        String input = "1.2";
+
+        var versionNumber = VersionNumber.fromString( input );
+
+        // Assert all components are as expected
+        assertThat( versionNumber.getMajorNumber() ).isEqualTo( 1 );
+        assertThat( versionNumber.getMinorNumber() ).isEqualTo( 2 );
+        assertThat( versionNumber.getPatchNumber() ).isZero();
+    }
+
+    @Test
+    void failIfStringIsTooShort() {
+        // Too short, major and minor parts are mandatory
+        String input = "1";
+
+        // Should throw IllegalArgumentException
+        assertThatIllegalArgumentException().isThrownBy( () -> VersionNumber.fromString( input ) );
+    }
+
+    @Test
+    void failIfInvalidCharacters() {
+        // 3sa is not a valid number
+        String input = "1.2.3sa";
+
+        // Should throw IllegalArgumentException with a root cause of NumberFormatException
+        assertThatIllegalArgumentException().isThrownBy( () -> VersionNumber.fromString( input ) )
+            .withCauseInstanceOf( NumberFormatException.class );
+    }
+
+    @Test
+    void failIfTooLong() {
+        // Too long, versions only have 3 parts
+        String input = "1.2.3.4";
+
+        // Should throw IllegalArgumentException
+        assertThatIllegalArgumentException().isThrownBy( () -> VersionNumber.fromString( input ) );
+    }
+}

--- a/src/test/java/eu/cessda/cvs/utils/VersionUtilsTest.java
+++ b/src/test/java/eu/cessda/cvs/utils/VersionUtilsTest.java
@@ -15,6 +15,7 @@
  */
 package eu.cessda.cvs.utils;
 
+import eu.cessda.cvs.domain.enumeration.ItemType;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,7 +44,7 @@ public class VersionUtilsTest {
         assertThat( VersionUtils.compareVersion("2.10.0","10.10.0")).isNegative();
         assertThat( VersionUtils.compareVersion("10.10.0","2.10.0")).isPositive();
     }
-    
+
     @Test
     void compareVersionTestMixedDigits(){
         assertThat( VersionUtils.compareVersion("2.0.1","1.2")).isPositive();
@@ -102,10 +103,14 @@ public class VersionUtilsTest {
 
     @Test
     void splitLanguageVersionTest(){
-        String[] methodOutput1 = {"2.1", "2.1", "en", "SL"};
+        LanguageVersion methodOutput1 = new LanguageVersion(
+            VersionNumber.fromString("2.1"), "en", ItemType.SL
+        );
         assertThat( VersionUtils.splitLanguageVersion("en-2.1")).isEqualTo(methodOutput1);
 
-        String[] methodOutput2 = {"2.0", "2.0.1", "de", "TL"};
+        LanguageVersion methodOutput2 = new LanguageVersion(
+            VersionNumber.fromString("2.0.1"), "de", ItemType.TL
+        );
         assertThat( VersionUtils.splitLanguageVersion("de-2.0.1")).isEqualTo(methodOutput2);
     }
 }

--- a/src/test/java/eu/cessda/cvs/web/rest/EditorResourceIT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/EditorResourceIT.java
@@ -28,7 +28,6 @@ import eu.cessda.cvs.service.dto.MetadataValueDTO;
 import eu.cessda.cvs.service.mapper.CommentMapper;
 import eu.cessda.cvs.service.mapper.MetadataValueMapper;
 import eu.cessda.cvs.utils.VersionNumber;
-import eu.cessda.cvs.utils.VocabularyUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -616,7 +615,7 @@ class EditorResourceIT {
         final Vocabulary vocabulary = vocabularyRepository.findAllByNotation(version.getNotation()).stream().findAny().orElseThrow();
         assertThat(vocabulary).isNotNull();
         // sort to make sure that the order is correct from latest to oldest
-        final List<Version> versions = vocabulary.getVersions().stream().sorted(VocabularyUtils.VERSION_COMPARATOR).collect(Collectors.toList());
+        final List<Version> versions = vocabulary.getVersions().stream().sorted().collect(Collectors.toList());
 
         final Version versionSl = versions.stream().filter(v -> v.getItemType() == ITEM_TYPE_SL ).findFirst().orElse(null);
         assertThat(versionSl).isNotNull();
@@ -1194,7 +1193,7 @@ class EditorResourceIT {
         assertThat(testVocabulary).isNotNull();
         // sort to make sure that the order is correct from latest to oldest
         final List<Version> versions = testVocabulary.getVersions().stream()
-            .sorted(VocabularyUtils.VERSION_COMPARATOR).collect(Collectors.toList());
+            .sorted().collect(Collectors.toList());
 
         version = versions.stream().filter( v -> v.getLanguage().equals( lang))
             .findFirst().orElse(null);

--- a/src/test/java/eu/cessda/cvs/web/rest/EditorResourceIT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/EditorResourceIT.java
@@ -376,15 +376,15 @@ class EditorResourceIT {
         // ActionType.ADD_TL_CV
         Version tlVersion = addVocabularyTranslationTest( slVersion );
         // Code translate for slConceptRoot1 ~ ActionType.ADD_TL_CV
-        Concept tlConcept1 = addTlConceptTest(tlVersion, slConceptRoot1, INIT_CODE_TL_TITLE, INIT_CODE_TL_DEFINITION);
+        Concept tlConcept1 = addTlConceptTest(tlVersion, slConceptRoot1 );
         // Code translate for slConceptRoot2 ~ ActionType.ADD_TL_CV
-        addTlConceptTest(tlVersion, slConceptRoot2, INIT_CODE_TL_TITLE, INIT_CODE_TL_DEFINITION);
+        addTlConceptTest(tlVersion, slConceptRoot2 );
         // ActionType.EDIT_TL_CODE
         editTlConceptTest(slConceptRoot1, tlVersion, tlConcept1);
         // ActionType.DELETE_TL_CODE
         deleteTlConceptTest(slConceptRoot1, tlVersion, tlConcept1);
         // Restore Code translate for slConceptRoot1 ~ ActionType.ADD_TL_CV
-        addTlConceptTest(tlVersion, slConceptRoot1, INIT_CODE_TL_TITLE, INIT_CODE_TL_DEFINITION);
+        addTlConceptTest(tlVersion, slConceptRoot1 );
         // ActionType.FORWARD_CV_TL_STATUS_REVIEW
         forwardTlStatusReviewTest( tlVersion );
         // ActionType.FORWARD_CV_TL_STATUS_READY_TO_PUBLISH
@@ -764,7 +764,7 @@ class EditorResourceIT {
         assertThat(tlConcept1.getDefinition()).isEqualTo(EDIT_CODE_TL_DEFINITION);
     }
 
-    private Concept addTlConceptTest(Version tlVersion, Concept slConcept, String title, String definition) throws Exception {
+    private Concept addTlConceptTest( Version tlVersion, Concept slConcept ) throws Exception {
         CodeSnippet codeSnippetForDeTl = new CodeSnippet();
         codeSnippetForDeTl.setActionType( ActionType.ADD_TL_CODE );
         Concept tlConcept = tlVersion.getConcepts().stream().filter(c -> c.getNotation().equals(slConcept.getNotation()))
@@ -772,8 +772,8 @@ class EditorResourceIT {
         assertThat(tlVersion).isNotNull();
         codeSnippetForDeTl.setVersionId( tlVersion.getId() );
         codeSnippetForDeTl.setConceptId( tlConcept.getId() );
-        codeSnippetForDeTl.setTitle(title);
-        codeSnippetForDeTl.setDefinition(definition);
+        codeSnippetForDeTl.setTitle( EditorResourceIT.INIT_CODE_TL_TITLE );
+        codeSnippetForDeTl.setDefinition( EditorResourceIT.INIT_CODE_TL_DEFINITION );
         restMockMvc.perform(put("/api/editors/codes")
             .header("Authorization", jwt)
             .contentType(MediaType.APPLICATION_JSON)
@@ -781,8 +781,8 @@ class EditorResourceIT {
             .andExpect(status().isOk());
         tlConcept = getConceptFromVocabulary(slConcept);
         assertThat(tlConcept).isNotNull();
-        assertThat(tlConcept.getTitle()).isEqualTo(title);
-        assertThat(tlConcept.getDefinition()).isEqualTo(definition);
+        assertThat(tlConcept.getTitle()).isEqualTo( EditorResourceIT.INIT_CODE_TL_TITLE );
+        assertThat(tlConcept.getDefinition()).isEqualTo( EditorResourceIT.INIT_CODE_TL_DEFINITION );
         return tlConcept;
     }
 

--- a/src/test/java/eu/cessda/cvs/web/rest/EditorResourceIT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/EditorResourceIT.java
@@ -49,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static eu.cessda.cvs.web.rest.utils.ResourceUtils.MEDIATYPE_JSONLD_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1052,7 +1053,7 @@ class EditorResourceIT {
             slVersion.getLanguage() + "&query=" + slConceptRoot1.getNotation()+ "&vocab=" +
             slVersion.getNotation()))
             .andExpect(status().isOk())
-            .andExpect(content().contentType(VocabularyResourceV2.JSONLD_TYPE))
+            .andExpect(content().contentType(MEDIATYPE_JSONLD_VALUE))
             .andExpect(jsonPath("$.results.[*].notation").value(hasItem(slConceptRoot1.getNotation())))
             .andExpect(jsonPath("$.results.[*].prefLabel").value(hasItem(slConceptRoot1.getTitle())))
             .andExpect(jsonPath("$.results.[*].definition").value(hasItem(slConceptRoot1.getDefinition())));
@@ -1061,7 +1062,7 @@ class EditorResourceIT {
             slVersion.getLanguage() + "&query=" + slConceptRoot1.getNotation().substring(3) + "*"+ "&vocab=" +
             slVersion.getNotation()))
             .andExpect(status().isOk())
-            .andExpect(content().contentType(VocabularyResourceV2.JSONLD_TYPE))
+            .andExpect(content().contentType(MEDIATYPE_JSONLD_VALUE))
             .andExpect(jsonPath("$.results.[*].notation").value(hasItem(slConceptRoot1.getNotation())))
             .andExpect(jsonPath("$.results.[*].prefLabel").value(hasItem(slConceptRoot1.getTitle())))
             .andExpect(jsonPath("$.results.[*].definition").value(hasItem(slConceptRoot1.getDefinition())));

--- a/src/test/java/eu/cessda/cvs/web/rest/VocabularyResourceV2IT.java
+++ b/src/test/java/eu/cessda/cvs/web/rest/VocabularyResourceV2IT.java
@@ -54,6 +54,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+import static eu.cessda.cvs.web.rest.utils.ResourceUtils.MEDIATYPE_JSONLD_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -207,9 +208,9 @@ class VocabularyResourceV2IT {
 
         restMockMvc.perform(get("/v2/search/vocabularies?query=" + EditorResourceIT.INIT_TITLE_EN +
             "&agency=" + EditorResourceIT.INIT_AGENCY_NAME + "&lang=" + EditorResourceIT.SOURCE_LANGUAGE)
-            .accept(VocabularyResourceV2.JSONLD_TYPE))
+            .accept(MEDIATYPE_JSONLD_VALUE))
             .andExpect(status().isOk())
-            .andExpect(content().contentType(VocabularyResourceV2.JSONLD_TYPE));
+            .andExpect(content().contentType(MEDIATYPE_JSONLD_VALUE));
     }
 
     @Test
@@ -218,7 +219,7 @@ class VocabularyResourceV2IT {
         restMockMvc.perform(get("/v2/search/codes?query=" + EditorResourceIT.INIT_CODE_NOTATION +
             "&agency=" + EditorResourceIT.INIT_AGENCY_NAME + "&lang=" + EditorResourceIT.SOURCE_LANGUAGE +
             "&vocab=" + EditorResourceIT.INIT_NAME)
-            .accept(VocabularyResourceV2.JSONLD_TYPE))
+            .accept(MEDIATYPE_JSONLD_VALUE))
             .andExpect(status().isOk())
             .andExpect( jsonPath( "$.results[0].vocab" ).value( EditorResourceIT.INIT_NAME ) );
     }
@@ -228,7 +229,7 @@ class VocabularyResourceV2IT {
     void searchCodesAgencyNullTest() throws Exception {
         restMockMvc.perform(get("/v2/search/codes?query=" + EditorResourceIT.INIT_CODE_NOTATION +
                 "&lang=" + EditorResourceIT.SOURCE_LANGUAGE + "&vocab=" + EditorResourceIT.INIT_NAME)
-                .accept(VocabularyResourceV2.JSONLD_TYPE))
+                .accept(MEDIATYPE_JSONLD_VALUE))
             .andExpect(status().isOk())
             .andExpect( jsonPath( "$.results[0].vocab" ).value( EditorResourceIT.INIT_NAME ) );
     }
@@ -239,7 +240,7 @@ class VocabularyResourceV2IT {
         restMockMvc.perform(get("/v2/search/codes?query=" + UUID.randomUUID() +
                 "&agency=" + EditorResourceIT.INIT_AGENCY_NAME + "&lang=" + EditorResourceIT.SOURCE_LANGUAGE +
                 "&vocab=" + EditorResourceIT.INIT_NAME)
-                .accept(VocabularyResourceV2.JSONLD_TYPE))
+                .accept(MEDIATYPE_JSONLD_VALUE))
             .andExpect(status().isOk())
             .andExpect( content().json( "{}" ) );
     }
@@ -250,7 +251,7 @@ class VocabularyResourceV2IT {
         MediaType.APPLICATION_JSON_VALUE,
         MediaType.APPLICATION_PDF_VALUE,
         MediaType.TEXT_HTML_VALUE,
-        VocabularyResourceV2.JSONLD_TYPE,
+        MEDIATYPE_JSONLD_VALUE,
         ExportService.MEDIATYPE_RDF_VALUE,
         ExportService.MEDIATYPE_WORD_VALUE
     } )


### PR DESCRIPTION
## REST Documentation

The REST documentation has been updated with clearer documentation, better explaining the public API and correctly exporting which MIME types are supported. Response codes have been documented and redundant values have been removed from the Swagger annotations

## VersionNumber Parser

The new VersionNumber parser no longer uses regular expressions. It is stricter about malformed input and is able to provide better exception messages when parsing fails.

The VersionNumber object can no longer be created with null major and minor components, and these are now represented as `int` fields in the object.

## VersionUtils.splitLanguageVersion() Improvements

VersionUtils.splitLanguageVersion() now returns a LanguageVersion object rather than a String array, allowing version numbers to be returned directly.

## Code Cleanup

- Remove unused Service.search() methods. These interface methods had implementations that only returned `null`.
- Replace use of the deprecated WebSecurityConfigurerAdapter interface